### PR TITLE
Keyword Extraction

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -27,6 +27,7 @@ libraryDependencies ++= Seq(
   "com.github.catalystcode" % "streaming-instagram_2.11" % "0.0.5",
   "com.github.catalystcode" % "streaming-facebook_2.11" % "0.0.1",
   "org.apache.bahir" %% "spark-streaming-twitter" % "2.1.0",
+  "org.apache.commons" % "commons-collections4" % "4.1",
   "com.microsoft.azure" %% "spark-streaming-eventhubs" % "2.0.5",
   "net.liftweb" %% "lift-json" % "3.0.1",
   "org.scalaj" %% "scalaj-http" % "2.3.0",

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/transforms/topic/KeywordExtractor.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/transforms/topic/KeywordExtractor.scala
@@ -1,6 +1,8 @@
 package com.microsoft.partnercatalyst.fortis.spark.transforms.topic
 
+import com.microsoft.partnercatalyst.fortis.spark.transforms.Tag
 import org.apache.commons.collections4.trie.PatriciaTrie
+
 import scala.collection.mutable.ListBuffer
 
 @SerialVersionUID(100L)
@@ -11,7 +13,7 @@ class KeywordExtractor(keyWords: Seq[String]) extends Serializable {
 
   originalCase.keys.foreach(keywordTrie.put(_, ()))
 
-  def extractKeywords(text: String): TraversableOnce[String] = {
+  def extractKeywords(text: String): List[Tag] = {
 
     def findMatches(segment: Seq[String]): Iterable[String] = {
       val sb = new StringBuilder()
@@ -31,6 +33,6 @@ class KeywordExtractor(keyWords: Seq[String]) extends Serializable {
     }
 
     val tokens = wordTokenizer.split(text.toLowerCase).toSeq
-    tokens.tails.flatMap(findMatches)
+    tokens.tails.flatMap(findMatches(_).map(Tag(_, 1))).toList
   }
 }

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/transforms/topic/KeywordExtractor.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/transforms/topic/KeywordExtractor.scala
@@ -1,0 +1,36 @@
+package com.microsoft.partnercatalyst.fortis.spark.transforms.topic
+
+import org.apache.commons.collections4.trie.PatriciaTrie
+import scala.collection.mutable.ListBuffer
+
+@SerialVersionUID(100L)
+class KeywordExtractor(keyWords: Seq[String]) extends Serializable {
+  private val wordTokenizer = """\b""".r
+  private val keywordTrie = new PatriciaTrie[Unit]()
+  private val originalCase = Map[String, String](keyWords.map(s => (s.toLowerCase, s)): _*)
+
+  originalCase.keys.foreach(keywordTrie.put(_, ()))
+
+  def extractKeywords(text: String): TraversableOnce[String] = {
+
+    def findMatches(segment: Seq[String]): Iterable[String] = {
+      val sb = new StringBuilder()
+      val result = ListBuffer[String]()
+
+      val it = segment.iterator
+      var prefix = ""
+      while (it.hasNext && !keywordTrie.prefixMap(prefix).isEmpty) {
+        prefix = sb.append(it.next()).mkString
+
+        if (keywordTrie.containsKey(prefix)) {
+          result.append(originalCase(prefix))
+        }
+      }
+
+      result
+    }
+
+    val tokens = wordTokenizer.split(text.toLowerCase).toSeq
+    tokens.tails.flatMap(findMatches)
+  }
+}

--- a/src/test/scala/com/microsoft/partnercatalyst/fortis/spark/streamprovider/StreamProviderSpec.scala
+++ b/src/test/scala/com/microsoft/partnercatalyst/fortis/spark/streamprovider/StreamProviderSpec.scala
@@ -75,6 +75,7 @@ class StreamProviderSpec extends FlatSpec with BeforeAndAfter {
       case Some(stream) => {
         val capture = mutable.ArrayBuffer[String]()
 
+        // TODO: does this really work on non-local deployments?
         stream.foreachRDD(capture ++= _.collect())
 
         // Start an then Stop gracefully so we can ensure we've collected all test items

--- a/src/test/scala/com/microsoft/partnercatalyst/fortis/spark/transforms/topic/KeywordExtractorSpec.scala
+++ b/src/test/scala/com/microsoft/partnercatalyst/fortis/spark/transforms/topic/KeywordExtractorSpec.scala
@@ -1,0 +1,66 @@
+package com.microsoft.partnercatalyst.fortis.spark.transforms.topic
+
+import org.scalatest.FlatSpec
+
+class KeywordExtractorSpec extends FlatSpec {
+  "The keyword extractor" should "extract overlapping keywords" in {
+    val keywords = List(
+      "The quick",
+      "quick brown",
+      "quick brown fox"
+    )
+
+    val extractor = new KeywordExtractor(keywords)
+
+    val matches = extractor.extractKeywords("The quick brown fox.").toList
+    assert(keywords.forall(matches.contains(_)))
+  }
+
+  it should "respect word boundaries" in {
+    val keywords = List(
+      "brown fox"
+    )
+
+    val extractor = new KeywordExtractor(keywords)
+
+    // "brown fox" should not be found since "brown" is not prefixed by a word boundary
+    var matches = extractor.extractKeywords("The quickbrown fox.")
+    assert(matches.isEmpty)
+
+    matches = extractor.extractKeywords("The 123brown fox.")
+    assert(matches.isEmpty)
+
+    // "brown fox" should not be found since fox is not postfixed by a word boundary
+    matches = extractor.extractKeywords("The quick brown foxjumped")
+    assert(matches.isEmpty)
+
+    matches = extractor.extractKeywords("The quick brown fox123")
+    assert(matches.isEmpty)
+
+    // "brown fox" *should* be found since a symbol like '#' creates a word boundary
+    matches = extractor.extractKeywords("The quick#brown fox#jumped")
+    assert(matches.nonEmpty)
+  }
+
+  it should "be case-insensitive but preserve keyword case" in {
+    val keywords = List(
+      "BROwN FoX"
+    )
+
+    val extractor = new KeywordExtractor(keywords)
+
+    val matches = extractor.extractKeywords("The quick browN fOx").toList
+    assert(matches.head == keywords.head)
+  }
+
+  it should "find keywords starting and ending with symbols anywhere" in {
+    val keywords = List(
+      "{testing}"
+    )
+
+    val extractor = new KeywordExtractor(keywords)
+
+    val matches = extractor.extractKeywords("Testing{testing}123")
+    assert(matches.head == keywords.head)
+  }
+}

--- a/src/test/scala/com/microsoft/partnercatalyst/fortis/spark/transforms/topic/KeywordExtractorSpec.scala
+++ b/src/test/scala/com/microsoft/partnercatalyst/fortis/spark/transforms/topic/KeywordExtractorSpec.scala
@@ -12,8 +12,8 @@ class KeywordExtractorSpec extends FlatSpec {
 
     val extractor = new KeywordExtractor(keywords)
 
-    val matches = extractor.extractKeywords("The quick brown fox.").toList
-    assert(keywords.forall(matches.contains(_)))
+    val matches = extractor.extractKeywords("The quick brown fox.").map(_.name)
+    assert(keywords.forall(keyword => matches.exists(m => keyword == m)))
   }
 
   it should "respect word boundaries" in {
@@ -49,7 +49,7 @@ class KeywordExtractorSpec extends FlatSpec {
 
     val extractor = new KeywordExtractor(keywords)
 
-    val matches = extractor.extractKeywords("The quick browN fOx").toList
+    val matches = extractor.extractKeywords("The quick browN fOx").map(_.name).toIterable
     assert(matches.head == keywords.head)
   }
 
@@ -60,7 +60,7 @@ class KeywordExtractorSpec extends FlatSpec {
 
     val extractor = new KeywordExtractor(keywords)
 
-    val matches = extractor.extractKeywords("Testing{testing}123")
+    val matches = extractor.extractKeywords("Testing{testing}123").map(_.name).toIterable
     assert(matches.head == keywords.head)
   }
 }


### PR DESCRIPTION
Adds keyword extraction to Fortis events.

Supports tagging events with single keywords and also with sequences of words (as defined by Java's word boundary tokenizer).

For example, "am so glad" will be found in the following:
"I am so glad my cat likes his cat food."

But not in:
"Iam so glad my cat likes his food."

See test spec for more examples of extraction behavior.