### PR TITLE
Improve serialization performance

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -31,6 +31,7 @@ libraryDependencies ++= Seq(
   "org.apache.bahir" %% "spark-streaming-twitter" % "2.1.0",
   "org.apache.commons" % "commons-collections4" % "4.1",
   "com.microsoft.azure" %% "spark-streaming-eventhubs" % "2.0.5",
+  "com.esotericsoftware.kryo" % "kryo" % "2.24.0",
   "net.liftweb" %% "lift-json" % "3.0.1",
   "org.scalaj" %% "scalaj-http" % "2.3.0",
   "net.lingala.zip4j" % "zip4j" % "1.3.2",

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/ProjectFortis.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/ProjectFortis.scala
@@ -9,10 +9,9 @@ import com.microsoft.partnercatalyst.fortis.spark.transforms.locations.{Geofence
 import com.microsoft.partnercatalyst.fortis.spark.transforms.locations.client.FeatureServiceClient
 import com.microsoft.partnercatalyst.fortis.spark.transforms.sentiment.{SentimentDetector, SentimentDetectorAuth}
 import com.microsoft.partnercatalyst.fortis.spark.transforms.topic.KeywordExtractor
-import org.apache.log4j.{Level, LogManager, Logger}
+import org.apache.log4j.{Level, Logger}
 import org.apache.spark.{SparkConf, SparkContext}
 import org.apache.spark.streaming.{Seconds, StreamingContext}
-import sun.reflect.generics.reflectiveObjects.NotImplementedException
 
 object ProjectFortis extends App {
 
@@ -71,6 +70,10 @@ object ProjectFortis extends App {
     val conf = new SparkConf()
       .setAppName(Constants.SparkAppName)
       .setIfMissing("spark.master", Constants.SparkMasterDefault)
+      .set("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
+      .set("spark.kryo.registrator", "com.microsoft.partnercatalyst.fortis.spark.serialization.KryoRegistrator")
+      .set("spark.kryoserializer.buffer", "128k")
+      .set("spark.kryoserializer.buffer.max", "64m")
 
     val ssc = new StreamingContext(
       new SparkContext(conf),

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/serialization/KryoRegistrator.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/serialization/KryoRegistrator.scala
@@ -1,0 +1,58 @@
+package com.microsoft.partnercatalyst.fortis.spark.serialization
+
+import com.esotericsoftware.kryo.Kryo
+import org.apache.spark.serializer.{KryoRegistrator => BaseKryoRegistrator}
+
+class KryoRegistrator extends BaseKryoRegistrator {
+  override def registerClasses(kryo: Kryo): Unit = {
+    // fortis
+    kryo.register(classOf[com.microsoft.partnercatalyst.fortis.spark.dto.AnalyzedItem[_]])
+    kryo.register(classOf[com.microsoft.partnercatalyst.fortis.spark.transforms.locations.Geofence])
+    kryo.register(classOf[com.microsoft.partnercatalyst.fortis.spark.transforms.locations.PlaceRecognizer])
+    kryo.register(classOf[com.microsoft.partnercatalyst.fortis.spark.transforms.locations.LocationsExtractor])
+    kryo.register(classOf[com.microsoft.partnercatalyst.fortis.spark.transforms.locations.client.FeatureServiceClient])
+    kryo.register(classOf[com.microsoft.partnercatalyst.fortis.spark.transforms.topic.KeywordExtractor])
+    kryo.register(classOf[com.microsoft.partnercatalyst.fortis.spark.transforms.image.ImageAnalyzer])
+    kryo.register(classOf[com.microsoft.partnercatalyst.fortis.spark.transforms.image.ImageAnalysisAuth])
+    kryo.register(classOf[com.microsoft.partnercatalyst.fortis.spark.transforms.language.LanguageDetector])
+    kryo.register(classOf[com.microsoft.partnercatalyst.fortis.spark.transforms.language.LanguageDetectorAuth])
+    kryo.register(classOf[com.microsoft.partnercatalyst.fortis.spark.transforms.sentiment.SentimentDetector])
+    kryo.register(classOf[com.microsoft.partnercatalyst.fortis.spark.transforms.sentiment.CognitiveServicesSentimentDetector])
+    kryo.register(classOf[com.microsoft.partnercatalyst.fortis.spark.transforms.sentiment.WordListSentimentDetector])
+    kryo.register(classOf[com.microsoft.partnercatalyst.fortis.spark.transforms.sentiment.SentimentDetectorAuth])
+
+    // twitter
+    kryo.register(classOf[twitter4j.Status])
+    kryo.register(classOf[twitter4j.GeoLocation])
+    kryo.register(classOf[twitter4j.Place])
+    kryo.register(classOf[twitter4j.User])
+    kryo.register(classOf[twitter4j.Scopes])
+
+    // facebook
+    kryo.register(classOf[facebook4j.Post])
+    kryo.register(classOf[facebook4j.Category])
+    kryo.register(classOf[facebook4j.Privacy])
+    kryo.register(classOf[facebook4j.Place])
+    kryo.register(classOf[facebook4j.Comment])
+    kryo.register(classOf[facebook4j.Application])
+    kryo.register(classOf[facebook4j.Targeting])
+
+    // tadaweb
+    kryo.register(classOf[com.microsoft.partnercatalyst.fortis.spark.tadaweb.dto.TadawebEvent])
+    kryo.register(classOf[com.microsoft.partnercatalyst.fortis.spark.tadaweb.dto.TadawebCity])
+    kryo.register(classOf[com.microsoft.partnercatalyst.fortis.spark.tadaweb.dto.TadawebTada])
+
+    // radio
+    kryo.register(classOf[com.microsoft.partnercatalyst.fortis.spark.streamwrappers.radio.RadioTranscription])
+
+    // instagram
+    kryo.register(classOf[com.github.catalystcode.fortis.spark.streaming.instagram.dto.InstagramItem])
+    kryo.register(classOf[com.github.catalystcode.fortis.spark.streaming.instagram.dto.InstagramUser])
+    kryo.register(classOf[com.github.catalystcode.fortis.spark.streaming.instagram.dto.InstagramLocation])
+    kryo.register(classOf[com.github.catalystcode.fortis.spark.streaming.instagram.dto.InstagramImages])
+    kryo.register(classOf[com.github.catalystcode.fortis.spark.streaming.instagram.dto.InstagramImage])
+    kryo.register(classOf[com.github.catalystcode.fortis.spark.streaming.instagram.dto.InstagramCaption])
+    kryo.register(classOf[com.github.catalystcode.fortis.spark.streaming.instagram.dto.InstagramLikes])
+    kryo.register(classOf[com.github.catalystcode.fortis.spark.streaming.instagram.dto.InstagramCaption])
+  }
+}


### PR DESCRIPTION
This PR switches our Spark setup to using the Kryo serializer for common DTO classes.

Unfortunately we can't enforce the use of the Kryo serializer for all classes (via the setting `spark.kryo.registrationRequired`) because some classes that we depend upon are non-public so we can't easily get a handle to them to register them in Kryo (e.g. TwitterReceiver).

Resolves #15