### PR TITLE
Rationalize item processing pipelines

### DIFF
--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/dto/AnalyzedItem.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/dto/AnalyzedItem.scala
@@ -1,11 +1,12 @@
 package com.microsoft.partnercatalyst.fortis.spark.dto
 
-case class AnalyzedItem[T](
-  originalItem: T,
+case class AnalyzedItem(
+  body: String,
+  title: String,
   source: String,
   sharedLocations: List[Location] = List(),
   analysis: Analysis
-) extends FortisItem
+)
 
 case class Analysis(
   language: Option[String] = None,

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/dto/FortisItem.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/dto/FortisItem.scala
@@ -1,7 +1,0 @@
-package com.microsoft.partnercatalyst.fortis.spark.dto
-
-trait FortisItem {
-  def source: String
-  def sharedLocations: List[Location]
-  def analysis: Analysis
-}

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/pipeline/FacebookPipeline.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/pipeline/FacebookPipeline.scala
@@ -1,52 +1,31 @@
 package com.microsoft.partnercatalyst.fortis.spark.pipeline
 
 import com.github.catalystcode.fortis.spark.streaming.facebook.dto.FacebookPost
-import com.microsoft.partnercatalyst.fortis.spark.dto.{Analysis, AnalyzedItem, FortisItem}
+import com.microsoft.partnercatalyst.fortis.spark.dto.{Analysis, AnalyzedItem}
 import com.microsoft.partnercatalyst.fortis.spark.streamprovider.{ConnectorConfig, StreamProvider}
 import org.apache.spark.streaming.StreamingContext
 import org.apache.spark.streaming.dstream.DStream
 
 object FacebookPipeline extends Pipeline {
-  override def apply(streamProvider: StreamProvider, streamRegistry: Map[String, List[ConnectorConfig]],
-    ssc: StreamingContext, transformContext: TransformContext): Option[DStream[FortisItem]] = {
+
+  override def apply(streamProvider: StreamProvider, streamRegistry: Map[String, List[ConnectorConfig]], ssc: StreamingContext, transformContext: TransformContext): Option[DStream[AnalyzedItem]] = {
+    streamProvider.buildStream[FacebookPost](ssc, streamRegistry("facebook")) match {
+      case None => None
+      case Some(stream) => Some(TextPipeline(convertToSchema(stream, transformContext), transformContext))
+    }
+  }
+
+  private def convertToSchema(stream: DStream[FacebookPost], transformContext: TransformContext): DStream[AnalyzedItem] = {
     import transformContext._
 
-    streamProvider.buildStream[FacebookPost](ssc, streamRegistry("facebook")).map(
-      stream => stream
-        .map(post => {
-          val source = post.post.getPermalinkUrl.toString
-          val language = languageDetector.detectLanguage(post.post.getMessage)
-          val analysis = Analysis(language = language, keywords = keywordExtractor.extractKeywords(post.post.getMessage))
-          AnalyzedItem(originalItem = post, analysis = analysis, source = source)
-        })
-        .filter(analyzedPost => {
-          supportedLanguages.contains(analyzedPost.analysis.language.getOrElse(""))
-        })
-        .map(analyzedPost => {
-          // sentiment detection
-          val text = analyzedPost.originalItem.post.getMessage
-          val language = analyzedPost.analysis.language.getOrElse("")
-          val inferredSentiment = sentimentDetector.detectSentiment(text, language).map(List(_)).getOrElse(List())
-          analyzedPost.copy(analysis = analyzedPost.analysis.copy(sentiments = inferredSentiment ++ analyzedPost.analysis.sentiments))
-        })
-        .map(analyzedPost => {
-          // map tagged locations to location features
-          var analyzed = analyzedPost
-          val place = Option(analyzed.originalItem.post.getPlace)
-          val location = if (place.isDefined) Some(place.get.getLocation) else None
-          if (location.isDefined) {
-            val lat = location.get.getLatitude
-            val lng = location.get.getLongitude
-            val sharedLocations = locationsExtractor.fetch(latitude = lat, longitude = lng).toList
-            analyzed = analyzed.copy(sharedLocations = sharedLocations ++ analyzed.sharedLocations)
-          }
-          analyzed
-        })
-        .map(analyzedPost => {
-          // infer locations from text
-          val inferredLocations = locationsExtractor.analyze(analyzedPost.originalItem.post.getMessage, analyzedPost.analysis.language).toList
-          analyzedPost.copy(analysis = analyzedPost.analysis.copy(locations = inferredLocations ++ analyzedPost.analysis.locations))
-        })
-    )
+    stream.map(post => AnalyzedItem(
+      body = post.post.getMessage,
+      title = "",
+      source = post.post.getPermalinkUrl.toString,
+      sharedLocations = Option(post.post.getPlace).map(_.getLocation) match {
+        case Some(location) => locationsExtractor.fetch(location.getLatitude, location.getLongitude).toList
+        case None => List()},
+      analysis = Analysis()
+    ))
   }
 }

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/pipeline/FacebookPipeline.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/pipeline/FacebookPipeline.scala
@@ -9,10 +9,8 @@ import org.apache.spark.streaming.dstream.DStream
 object FacebookPipeline extends Pipeline {
 
   override def apply(streamProvider: StreamProvider, streamRegistry: Map[String, List[ConnectorConfig]], ssc: StreamingContext, transformContext: TransformContext): Option[DStream[AnalyzedItem]] = {
-    streamProvider.buildStream[FacebookPost](ssc, streamRegistry("facebook")) match {
-      case None => None
-      case Some(stream) => Some(TextPipeline(convertToSchema(stream, transformContext), transformContext))
-    }
+    streamProvider.buildStream[FacebookPost](ssc, streamRegistry("facebook")).map(stream =>
+      TextPipeline(convertToSchema(stream, transformContext), transformContext))
   }
 
   private def convertToSchema(stream: DStream[FacebookPost], transformContext: TransformContext): DStream[AnalyzedItem] = {

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/pipeline/InstagramPipeline.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/pipeline/InstagramPipeline.scala
@@ -1,36 +1,32 @@
 package com.microsoft.partnercatalyst.fortis.spark.pipeline
 
 import com.github.catalystcode.fortis.spark.streaming.instagram.dto.InstagramItem
-import com.microsoft.partnercatalyst.fortis.spark.dto.{AnalyzedItem, FortisItem}
+import com.microsoft.partnercatalyst.fortis.spark.dto.AnalyzedItem
 import com.microsoft.partnercatalyst.fortis.spark.streamprovider.{ConnectorConfig, StreamProvider}
 import org.apache.spark.streaming.StreamingContext
 import org.apache.spark.streaming.dstream.DStream
 
 object InstagramPipeline extends Pipeline {
   override def apply(streamProvider: StreamProvider, streamRegistry: Map[String, List[ConnectorConfig]],
-    ssc: StreamingContext, transformContext: TransformContext): Option[DStream[FortisItem]] = {
+    ssc: StreamingContext, transformContext: TransformContext): Option[DStream[AnalyzedItem]] = {
     import transformContext._
 
-    streamProvider.buildStream[InstagramItem](ssc, streamRegistry("instagram")).map(
-      stream => stream
-        .map(instagram => {
-          // do computer vision analysis: keyword extraction, etc.
-          val source = instagram.link
-          var analysis = imageAnalyzer.analyze(instagram.images.standard_resolution.url)
-          analysis = analysis.copy(keywords = keywordExtractor.extractKeywords(instagram.caption.text))
-          AnalyzedItem(originalItem = instagram, analysis = analysis, source = source)
-        })
-        .map(analyzedInstagram => {
-          // map tagged locations to location features
-          var analyzed = analyzedInstagram
-          val instagram = analyzed.originalItem
-          if (instagram.location.isDefined) {
-            val location = instagram.location.get
-            val sharedLocations = locationsExtractor.fetch(latitude = location.latitude, longitude = location.longitude).toList
-            analyzed = analyzed.copy(sharedLocations = sharedLocations ++ analyzed.sharedLocations)
-          }
-          analyzed
-        })
-    )
+    streamProvider.buildStream[InstagramItem](ssc, streamRegistry("instagram")).map(_
+      .map(instagram => {
+        // do computer vision analysis
+        AnalyzedItem(
+          body = instagram.caption.text,
+          title = "",
+          sharedLocations = instagram.location match {
+            case Some(location) => locationsExtractor.fetch(location.latitude, location.longitude).toList
+            case None => List()},
+          analysis = imageAnalyzer.analyze(instagram.images.standard_resolution.url),
+          source = instagram.link)
+      })
+      .map(analyzedItem => {
+        // keyword extraction
+        val keywords = keywordExtractor.extractKeywords(analyzedItem.body)
+        analyzedItem.copy(analysis = analyzedItem.analysis.copy(keywords = keywords ::: analyzedItem.analysis.keywords))
+      }))
   }
 }

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/pipeline/Pipeline.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/pipeline/Pipeline.scala
@@ -1,11 +1,11 @@
 package com.microsoft.partnercatalyst.fortis.spark.pipeline
 
-import com.microsoft.partnercatalyst.fortis.spark.dto.FortisItem
+import com.microsoft.partnercatalyst.fortis.spark.dto.AnalyzedItem
 import com.microsoft.partnercatalyst.fortis.spark.streamprovider.{ConnectorConfig, StreamProvider}
 import org.apache.spark.streaming.StreamingContext
 import org.apache.spark.streaming.dstream.DStream
 
 trait Pipeline {
   def apply(streamProvider: StreamProvider, streamRegistry: Map[String, List[ConnectorConfig]], ssc: StreamingContext,
-    transformContext: TransformContext): Option[DStream[FortisItem]]
+    transformContext: TransformContext): Option[DStream[AnalyzedItem]]
 }

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/pipeline/RadioPipeline.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/pipeline/RadioPipeline.scala
@@ -9,10 +9,8 @@ import org.apache.spark.streaming.dstream.DStream
 object RadioPipeline extends Pipeline {
 
   override def apply(streamProvider: StreamProvider, streamRegistry: Map[String, List[ConnectorConfig]], ssc: StreamingContext, transformContext: TransformContext): Option[DStream[AnalyzedItem]] = {
-    streamProvider.buildStream[RadioTranscription](ssc, streamRegistry("radio")) match {
-      case None => None
-      case Some(stream) => Some(TextPipeline(convertToSchema(stream, transformContext), transformContext))
-    }
+    streamProvider.buildStream[RadioTranscription](ssc, streamRegistry("radio")).map(stream =>
+      TextPipeline(convertToSchema(stream, transformContext), transformContext))
   }
 
   private def convertToSchema(stream: DStream[RadioTranscription], transformContext: TransformContext): DStream[AnalyzedItem] = {

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/pipeline/RadioPipeline.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/pipeline/RadioPipeline.scala
@@ -1,40 +1,27 @@
 package com.microsoft.partnercatalyst.fortis.spark.pipeline
 
-import com.microsoft.partnercatalyst.fortis.spark.dto.{Analysis, AnalyzedItem, FortisItem}
+import com.microsoft.partnercatalyst.fortis.spark.dto.{Analysis, AnalyzedItem}
 import com.microsoft.partnercatalyst.fortis.spark.streamprovider.{ConnectorConfig, StreamProvider}
 import com.microsoft.partnercatalyst.fortis.spark.streamwrappers.radio.RadioTranscription
 import org.apache.spark.streaming.StreamingContext
 import org.apache.spark.streaming.dstream.DStream
 
 object RadioPipeline extends Pipeline {
-  override def apply(streamProvider: StreamProvider, streamRegistry: Map[String, List[ConnectorConfig]],
-    ssc: StreamingContext, transformContext: TransformContext): Option[DStream[FortisItem]] = {
-    import transformContext._
 
-    streamProvider.buildStream[RadioTranscription](ssc, streamRegistry("radio")).map(
-      stream => stream
-        .map(radioTranscription => {
-          val language = Some(radioTranscription.language)
-          val keywords = keywordExtractor.extractKeywords(radioTranscription.text)
-          val analysis = Analysis(language = language, keywords = keywords)
-          val source = radioTranscription.radioUrl
-          AnalyzedItem(originalItem = radioTranscription, analysis = analysis, source = source)
-        })
-        .filter(analyzedRadio => {
-          supportedLanguages.contains(analyzedRadio.analysis.language.getOrElse(""))
-        })
-        .map(analyzedRadio => {
-          // sentiment detection
-          val text = analyzedRadio.originalItem.text
-          val language = analyzedRadio.analysis.language.getOrElse("")
-          val inferredSentiment = sentimentDetector.detectSentiment(text, language).map(List(_)).getOrElse(List())
-          analyzedRadio.copy(analysis = analyzedRadio.analysis.copy(sentiments = inferredSentiment ++ analyzedRadio.analysis.sentiments))
-        })
-        .map(analyzedRadio => {
-          // infer locations from text
-          val inferredLocations = locationsExtractor.analyze(analyzedRadio.originalItem.text, analyzedRadio.analysis.language).toList
-          analyzedRadio.copy(analysis = analyzedRadio.analysis.copy(locations = inferredLocations ++ analyzedRadio.analysis.locations))
-        })
-    )
+  override def apply(streamProvider: StreamProvider, streamRegistry: Map[String, List[ConnectorConfig]], ssc: StreamingContext, transformContext: TransformContext): Option[DStream[AnalyzedItem]] = {
+    streamProvider.buildStream[RadioTranscription](ssc, streamRegistry("radio")) match {
+      case None => None
+      case Some(stream) => Some(TextPipeline(convertToSchema(stream, transformContext), transformContext))
+    }
+  }
+
+  private def convertToSchema(stream: DStream[RadioTranscription], transformContext: TransformContext): DStream[AnalyzedItem] = {
+    stream.map(transcription => AnalyzedItem(
+      body = transcription.text,
+      title = "",
+      source = transcription.radioUrl,
+      analysis = Analysis(
+        language = Some(transcription.language)
+      )))
   }
 }

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/pipeline/TadawebPipeline.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/pipeline/TadawebPipeline.scala
@@ -1,6 +1,6 @@
 package com.microsoft.partnercatalyst.fortis.spark.pipeline
 
-import com.microsoft.partnercatalyst.fortis.spark.dto.{Analysis, AnalyzedItem, FortisItem}
+import com.microsoft.partnercatalyst.fortis.spark.dto.{Analysis, AnalyzedItem}
 import com.microsoft.partnercatalyst.fortis.spark.streamprovider.{ConnectorConfig, StreamProvider}
 import com.microsoft.partnercatalyst.fortis.spark.tadaweb.dto.TadawebEvent
 import com.microsoft.partnercatalyst.fortis.spark.transforms.sentiment.SentimentDetector
@@ -8,62 +8,30 @@ import org.apache.spark.streaming.StreamingContext
 import org.apache.spark.streaming.dstream.DStream
 
 object TadawebPipeline extends Pipeline {
-  override def apply(streamProvider: StreamProvider, streamRegistry: Map[String, List[ConnectorConfig]],
-    ssc: StreamingContext, transformContext: TransformContext): Option[DStream[FortisItem]] = {
+  override def apply(streamProvider: StreamProvider, streamRegistry: Map[String, List[ConnectorConfig]], ssc: StreamingContext, transformContext: TransformContext): Option[DStream[AnalyzedItem]] = {
+    streamProvider.buildStream[TadawebEvent](ssc, streamRegistry("tadaweb")) match {
+      case None => None
+      case Some(stream) => Some(TextPipeline(convertToSchema(stream, transformContext), transformContext))
+    }
+  }
+
+  private def convertToSchema(stream: DStream[TadawebEvent], transformContext: TransformContext): DStream[AnalyzedItem] = {
     import transformContext._
 
-    streamProvider.buildStream[TadawebEvent](ssc, streamRegistry("tadaweb")).map(
-      stream => stream
-        .map(event => AnalyzedItem(
-          event,
-          source = event.tada.name,
-          analysis = Analysis(keywords =
-            keywordExtractor.extractKeywords(event.text) ::: keywordExtractor.extractKeywords(event.title)
-          )
-        ))
-        .filter(_.analysis.keywords.nonEmpty)
-        .map(fortisEvent => {
-          val language = languageDetector.detectLanguage(fortisEvent.originalItem.text)
-          val sentiment: Option[Double] = fortisEvent.originalItem.sentiment match {
-            case "negative" => Some(SentimentDetector.Negative)
-            case "neutral" => Some(SentimentDetector.Neutral)
-            case "positive" => Some(SentimentDetector.Positive)
-            case _ => language match {
-              case Some(lang) =>
-                sentimentDetector.detectSentiment(fortisEvent.originalItem.text, lang)
-              case None => None
-            }
-          }
-
-          fortisEvent.copy(
-            analysis = fortisEvent.analysis.copy(
-              language = language,
-              sentiments = sentiment.toList ::: fortisEvent.analysis.sentiments
-            )
-          )
-        })
-        .filter(_.analysis.sentiments.nonEmpty)
-        .map(fortisEvent => {
-          val sharedLocations = fortisEvent.originalItem.cities.flatMap(city =>
-            city.coordinates match {
-              case Seq(latitude, longitude) => locationsExtractor.fetch(latitude = latitude, longitude = longitude)
-              case _ => None
-            }
-          ).toList
-
-          fortisEvent.copy(
-            sharedLocations = sharedLocations ::: fortisEvent.sharedLocations
-          )
-        })
-        .map(fortisEvent => {
-          val inferredLocations = locationsExtractor.analyze(fortisEvent.originalItem.text, fortisEvent.analysis.language)
-
-          fortisEvent.copy(
-            analysis = fortisEvent.analysis.copy(
-              locations = inferredLocations.toList ::: fortisEvent.analysis.locations
-            )
-          )
-        })
-    )
+    stream.map(tada => AnalyzedItem(
+      body = tada.text,
+      title = tada.title,
+      source = tada.tada.name,
+      sharedLocations = tada.cities.flatMap(city => city.coordinates match {
+        case Seq(latitude, longitude) => locationsExtractor.fetch(latitude, longitude)
+        case _ => None
+      }).toList,
+      analysis = Analysis(
+        sentiments = tada.sentiment match {
+          case "negative" => List(SentimentDetector.Negative)
+          case "neutral" => List(SentimentDetector.Neutral)
+          case "positive" => List(SentimentDetector.Positive)
+          case _ => List()}
+      )))
   }
 }

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/pipeline/TadawebPipeline.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/pipeline/TadawebPipeline.scala
@@ -9,10 +9,8 @@ import org.apache.spark.streaming.dstream.DStream
 
 object TadawebPipeline extends Pipeline {
   override def apply(streamProvider: StreamProvider, streamRegistry: Map[String, List[ConnectorConfig]], ssc: StreamingContext, transformContext: TransformContext): Option[DStream[AnalyzedItem]] = {
-    streamProvider.buildStream[TadawebEvent](ssc, streamRegistry("tadaweb")) match {
-      case None => None
-      case Some(stream) => Some(TextPipeline(convertToSchema(stream, transformContext), transformContext))
-    }
+    streamProvider.buildStream[TadawebEvent](ssc, streamRegistry("tadaweb")).map(stream =>
+      TextPipeline(convertToSchema(stream, transformContext), transformContext))
   }
 
   private def convertToSchema(stream: DStream[TadawebEvent], transformContext: TransformContext): DStream[AnalyzedItem] = {

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/pipeline/TextPipeline.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/pipeline/TextPipeline.scala
@@ -26,20 +26,32 @@ object TextPipeline {
     })
     .map(analyzedItem => {
       // keywords extraction
-      val bodyKewords = keywordExtractor.extractKeywords(analyzedItem.body)
-      val titleKeywords = keywordExtractor.extractKeywords(analyzedItem.title)
-      val keywords = titleKeywords ::: bodyKewords
-      analyzedItem.copy(analysis = analyzedItem.analysis.copy(keywords = keywords ::: analyzedItem.analysis.keywords))
+      analyzedItem.analysis.keywords.length match {
+        case 0 =>
+          val bodyKewords = keywordExtractor.extractKeywords(analyzedItem.body)
+          val titleKeywords = keywordExtractor.extractKeywords(analyzedItem.title)
+          val keywords = titleKeywords ::: bodyKewords
+          analyzedItem.copy(analysis = analyzedItem.analysis.copy(keywords = keywords))
+        case _ => analyzedItem
+      }
     })
     .map(analyzedItem => {
       // analyze sentiment
-      val sentiments = sentimentDetector.detectSentiment(analyzedItem.body, analyzedItem.analysis.language.getOrElse("")).map(List(_)).getOrElse(List())
-      analyzedItem.copy(analysis = analyzedItem.analysis.copy(sentiments = sentiments ::: analyzedItem.analysis.sentiments))
+      analyzedItem.analysis.sentiments.length match {
+        case 0 =>
+          val sentiments = sentimentDetector.detectSentiment(analyzedItem.body, analyzedItem.analysis.language.getOrElse("")).map(List(_)).getOrElse(List())
+          analyzedItem.copy(analysis = analyzedItem.analysis.copy(sentiments = sentiments))
+        case _ => analyzedItem
+      }
     })
     .map(analyzedItem => {
       // infer locations from text
-      val locations = locationsExtractor.analyze(analyzedItem.body, analyzedItem.analysis.language).toList
-      analyzedItem.copy(analysis = analyzedItem.analysis.copy(locations = locations ::: analyzedItem.analysis.locations))
+      analyzedItem.analysis.locations.length match {
+        case 0 =>
+          val locations = locationsExtractor.analyze(analyzedItem.body, analyzedItem.analysis.language).toList
+          analyzedItem.copy(analysis = analyzedItem.analysis.copy(locations = locations))
+        case _ => analyzedItem
+      }
     })
   }
 }

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/pipeline/TextPipeline.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/pipeline/TextPipeline.scala
@@ -1,0 +1,45 @@
+package com.microsoft.partnercatalyst.fortis.spark.pipeline
+
+import com.microsoft.partnercatalyst.fortis.spark.dto.AnalyzedItem
+import org.apache.spark.streaming.dstream.DStream
+
+object TextPipeline {
+  def apply(stream: DStream[AnalyzedItem], transformContext: TransformContext): DStream[AnalyzedItem] = {
+    import transformContext._
+
+    stream
+    .map(analyzedItem => {
+      // language inference
+      analyzedItem.analysis.language match {
+        case Some(_) => analyzedItem
+        case None =>
+          val language = languageDetector.detectLanguage(analyzedItem.body)
+          analyzedItem.copy(analysis = analyzedItem.analysis.copy(language = language))
+      }
+    })
+    .filter(analyzedItem => {
+      // restrict to supported languages
+      analyzedItem.analysis.language match {
+        case None => false
+        case Some(language) => supportedLanguages.contains(language)
+      }
+    })
+    .map(analyzedItem => {
+      // keywords extraction
+      val bodyKewords = keywordExtractor.extractKeywords(analyzedItem.body)
+      val titleKeywords = keywordExtractor.extractKeywords(analyzedItem.title)
+      val keywords = titleKeywords ::: bodyKewords
+      analyzedItem.copy(analysis = analyzedItem.analysis.copy(keywords = keywords ::: analyzedItem.analysis.keywords))
+    })
+    .map(analyzedItem => {
+      // analyze sentiment
+      val sentiments = sentimentDetector.detectSentiment(analyzedItem.body, analyzedItem.analysis.language.getOrElse("")).map(List(_)).getOrElse(List())
+      analyzedItem.copy(analysis = analyzedItem.analysis.copy(sentiments = sentiments ::: analyzedItem.analysis.sentiments))
+    })
+    .map(analyzedItem => {
+      // infer locations from text
+      val locations = locationsExtractor.analyze(analyzedItem.body, analyzedItem.analysis.language).toList
+      analyzedItem.copy(analysis = analyzedItem.analysis.copy(locations = locations ::: analyzedItem.analysis.locations))
+    })
+  }
+}

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/pipeline/TwitterPipeline.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/pipeline/TwitterPipeline.scala
@@ -1,51 +1,32 @@
 package com.microsoft.partnercatalyst.fortis.spark.pipeline
 
-import com.microsoft.partnercatalyst.fortis.spark.dto.{Analysis, AnalyzedItem, FortisItem}
+import com.microsoft.partnercatalyst.fortis.spark.dto.{Analysis, AnalyzedItem}
 import com.microsoft.partnercatalyst.fortis.spark.streamprovider.{ConnectorConfig, StreamProvider}
 import org.apache.spark.streaming.StreamingContext
 import org.apache.spark.streaming.dstream.DStream
 import twitter4j.{Status => TwitterStatus}
 
 object TwitterPipeline extends Pipeline {
-  override def apply(streamProvider: StreamProvider, streamRegistry: Map[String, List[ConnectorConfig]],
-    ssc: StreamingContext, transformContext: TransformContext): Option[DStream[FortisItem]] = {
+
+  override def apply(streamProvider: StreamProvider, streamRegistry: Map[String, List[ConnectorConfig]], ssc: StreamingContext, transformContext: TransformContext): Option[DStream[AnalyzedItem]] = {
+    streamProvider.buildStream[TwitterStatus](ssc, streamRegistry("twitter")) match {
+      case None => None
+      case Some(stream) => Some(TextPipeline(convertToSchema(stream, transformContext), transformContext))
+    }
+  }
+
+  private def convertToSchema(stream: DStream[TwitterStatus], transformContext: TransformContext): DStream[AnalyzedItem] = {
     import transformContext._
 
-    streamProvider.buildStream[TwitterStatus](ssc, streamRegistry("twitter")).map(
-      stream => stream
-        .map(tweet => {
-          val source = s"https://twitter.com/statuses/${tweet.getId}"
-          val language = if (Option(tweet.getLang).isDefined) { Option(tweet.getLang) } else { languageDetector.detectLanguage(tweet.getText) }
-          val analysis = Analysis(language = language, keywords = keywordExtractor.extractKeywords(tweet.getText))
-          AnalyzedItem(originalItem = tweet, analysis = analysis, source = source)
-        })
-        .filter(analyzedPost => {
-          supportedLanguages.contains(analyzedPost.analysis.language.getOrElse(""))
-        })
-        .map(analyzedPost => {
-          // sentiment detection
-          val text = analyzedPost.originalItem.getText
-          val language = analyzedPost.analysis.language.getOrElse("")
-          val inferredSentiment = sentimentDetector.detectSentiment(text, language).map(List(_)).getOrElse(List())
-          analyzedPost.copy(analysis = analyzedPost.analysis.copy(sentiments = inferredSentiment ++ analyzedPost.analysis.sentiments))
-        })
-        .map(analyzedTweet => {
-          // map tagged locations to location features
-          var analyzed = analyzedTweet
-          val location = analyzed.originalItem.getGeoLocation
-          if (location != null) {
-            val lat = location.getLatitude
-            val lng = location.getLongitude
-            val sharedLocations = locationsExtractor.fetch(latitude = lat, longitude = lng).toList
-            analyzed = analyzed.copy(sharedLocations = sharedLocations ++ analyzed.sharedLocations)
-          }
-          analyzed
-        })
-        .map(analyzedTweet => {
-          // infer locations from text
-          val inferredLocations = locationsExtractor.analyze(analyzedTweet.originalItem.getText, analyzedTweet.analysis.language).toList
-          analyzedTweet.copy(analysis = analyzedTweet.analysis.copy(locations = inferredLocations ++ analyzedTweet.analysis.locations))
-        })
-    )
+    stream.map(tweet => AnalyzedItem(
+      body = tweet.getText,
+      title = "",
+      source = s"https://twitter.com/statuses/${tweet.getId}",
+      sharedLocations = Option(tweet.getGeoLocation) match {
+        case Some(location) => locationsExtractor.fetch(location.getLatitude, location.getLongitude).toList
+        case None => List()},
+      analysis = Analysis(
+        language = Option(tweet.getLang)
+      )))
   }
 }

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/pipeline/TwitterPipeline.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/pipeline/TwitterPipeline.scala
@@ -9,10 +9,8 @@ import twitter4j.{Status => TwitterStatus}
 object TwitterPipeline extends Pipeline {
 
   override def apply(streamProvider: StreamProvider, streamRegistry: Map[String, List[ConnectorConfig]], ssc: StreamingContext, transformContext: TransformContext): Option[DStream[AnalyzedItem]] = {
-    streamProvider.buildStream[TwitterStatus](ssc, streamRegistry("twitter")) match {
-      case None => None
-      case Some(stream) => Some(TextPipeline(convertToSchema(stream, transformContext), transformContext))
-    }
+    streamProvider.buildStream[TwitterStatus](ssc, streamRegistry("twitter")).map(stream =>
+      TextPipeline(convertToSchema(stream, transformContext), transformContext))
   }
 
   private def convertToSchema(stream: DStream[TwitterStatus], transformContext: TransformContext): DStream[AnalyzedItem] = {

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/serialization/KryoRegistrator.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/serialization/KryoRegistrator.scala
@@ -10,7 +10,7 @@ class KryoRegistrator extends BaseKryoRegistrator {
     // so always add new classes at the end of this list
     // more information: https://stackoverflow.com/a/32869053/3817588
     // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-    kryo.register(classOf[com.microsoft.partnercatalyst.fortis.spark.dto.AnalyzedItem[_]])
+    kryo.register(classOf[com.microsoft.partnercatalyst.fortis.spark.dto.AnalyzedItem])
     kryo.register(classOf[com.microsoft.partnercatalyst.fortis.spark.transforms.locations.Geofence])
     kryo.register(classOf[com.microsoft.partnercatalyst.fortis.spark.transforms.locations.PlaceRecognizer])
     kryo.register(classOf[com.microsoft.partnercatalyst.fortis.spark.transforms.locations.LocationsExtractor])

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/transforms/language/LanguageDetector.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/transforms/language/LanguageDetector.scala
@@ -13,6 +13,10 @@ class LanguageDetector(
 ) extends Serializable {
 
   def detectLanguage(text: String): Option[String] = {
+    if (text.isEmpty) {
+      return None
+    }
+
     val textId = "0"
     val requestBody = buildRequestBody(text, textId)
     val response = callCognitiveServices(requestBody)

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/transforms/locations/LocationsExtractor.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/transforms/locations/LocationsExtractor.scala
@@ -32,6 +32,10 @@ class LocationsExtractor(
   }
 
   def analyze(text: String, language: Option[String] = None): Iterable[Location] = {
+    if (text.isEmpty) {
+      return List()
+    }
+
     val candidatePlaces = extractCandidatePlaces(text, language)
     val locationsInGeofence = candidatePlaces.flatMap(place => lookup.get(place.toLowerCase)).flatten.toSet
     locationsInGeofence.map(wofId => Location(wofId, confidence = Some(0.5)))

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/transforms/topic/KeywordExtractor.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/transforms/topic/KeywordExtractor.scala
@@ -11,6 +11,9 @@ class KeywordExtractor(keywords: Seq[String]) extends Serializable {
   @transient private lazy val keywordTrie = initializeTrie(keywords)
 
   def extractKeywords(text: String): List[Tag] = {
+    if (text.isEmpty) {
+      return List()
+    }
 
     def findMatches(segment: Seq[String]): Iterable[String] = {
       val sb = new StringBuilder()


### PR DESCRIPTION
We currently have a bunch of copy/paste code in the pipelines package which leads to poor maintainability because we need to make changes for new feature extractors in multiple places and because we can't guarantee uniform processing across all pipelines.

This pull request removes the copy/paste code and rationalizes the processing pipelines by introducing the TextPipeline class which is used by the Twitter, Facebook, Radio and Tadaweb pipelines.