### PR TITLE
Implement token blacklist filtering

### DIFF
--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/Pipeline.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/Pipeline.scala
@@ -6,7 +6,7 @@ import com.microsoft.partnercatalyst.fortis.spark.ProjectFortis.Settings
 import scala.reflect.runtime.universe.TypeTag
 import com.microsoft.partnercatalyst.fortis.spark.analyzer.{Analyzer, ExtendedFortisEvent}
 import com.microsoft.partnercatalyst.fortis.spark.dba.ConfigurationManager
-import com.microsoft.partnercatalyst.fortis.spark.dto.{Analysis, Details, FortisEvent}
+import com.microsoft.partnercatalyst.fortis.spark.dto.{Analysis, FortisEvent}
 import com.microsoft.partnercatalyst.fortis.spark.streamprovider.StreamProvider
 import com.microsoft.partnercatalyst.fortis.spark.transforms.ZipModelsProvider
 import com.microsoft.partnercatalyst.fortis.spark.transforms.image.{ImageAnalysisAuth, ImageAnalyzer}

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/Pipeline.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/Pipeline.scala
@@ -71,8 +71,8 @@ object Pipeline {
         analysis.keywords.nonEmpty
       }
 
-      def hasBlacklistedTerms(details: Details): Boolean = {
-        blacklist.matches(details.body) || blacklist.matches(details.title)
+      def hasBlacklistedTerms(event: ExtendedFortisEvent[T]): Boolean = {
+        analyzer.hasBlacklistedTerms(event.details, blacklist)
       }
 
       def addEntities(event: ExtendedFortisEvent[T]): ExtendedFortisEvent[T] = {
@@ -95,7 +95,7 @@ object Pipeline {
       // Configure analysis pipeline
       rdd
         .map(convertToSchema)
-        .filter(item => !hasBlacklistedTerms(item.details))
+        .filter(item => !hasBlacklistedTerms(item))
         .map(addLanguage)
         .filter(item => isLanguageSupported(item.analysis))
         .map(addKeywords)

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/Pipeline.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/Pipeline.scala
@@ -11,9 +11,8 @@ import com.microsoft.partnercatalyst.fortis.spark.streamprovider.StreamProvider
 import com.microsoft.partnercatalyst.fortis.spark.transforms.ZipModelsProvider
 import com.microsoft.partnercatalyst.fortis.spark.transforms.image.{ImageAnalysisAuth, ImageAnalyzer}
 import com.microsoft.partnercatalyst.fortis.spark.transforms.language.{LanguageDetector, LanguageDetectorAuth}
-import com.microsoft.partnercatalyst.fortis.spark.transforms.locations.{Geofence, LocationsExtractor, LocationsExtractorFactory, PlaceRecognizer}
+import com.microsoft.partnercatalyst.fortis.spark.transforms.locations.{Geofence, LocationsExtractorFactory, PlaceRecognizer}
 import com.microsoft.partnercatalyst.fortis.spark.transforms.locations.client.FeatureServiceClient
-import com.microsoft.partnercatalyst.fortis.spark.transforms.nlp.Tokenizer
 import com.microsoft.partnercatalyst.fortis.spark.transforms.people.PeopleRecognizer
 import com.microsoft.partnercatalyst.fortis.spark.transforms.sentiment.{SentimentDetector, SentimentDetectorAuth}
 import com.microsoft.partnercatalyst.fortis.spark.transforms.topic.{Blacklist, KeywordExtractor}

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/analyzer/AnalysisDefaults.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/analyzer/AnalysisDefaults.scala
@@ -19,7 +19,7 @@ private[analyzer] object AnalysisDefaults {
     with EnableLocation[T]
     with EnableEntity[T]
     with EnableLanguage[T]
-    with FilterBlacklist[T]
+    with EnableBlacklist[T]
     with EnableSentiment[T] {
     this: Analyzer[T] =>
   }
@@ -61,7 +61,7 @@ private[analyzer] object AnalysisDefaults {
     }
   }
 
-  trait FilterBlacklist[T] {
+  trait EnableBlacklist[T] {
     this: Analyzer[T] =>
     override def hasBlacklistedTerms(details: ExtendedDetails[T], blacklist: Blacklist): Boolean = {
       blacklist.matches(details.body) || blacklist.matches(details.title)

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/analyzer/AnalysisDefaults.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/analyzer/AnalysisDefaults.scala
@@ -5,7 +5,7 @@ import com.microsoft.partnercatalyst.fortis.spark.transforms.language.LanguageDe
 import com.microsoft.partnercatalyst.fortis.spark.transforms.locations.LocationsExtractor
 import com.microsoft.partnercatalyst.fortis.spark.transforms.people.PeopleRecognizer
 import com.microsoft.partnercatalyst.fortis.spark.transforms.sentiment.SentimentDetector
-import com.microsoft.partnercatalyst.fortis.spark.transforms.topic.KeywordExtractor
+import com.microsoft.partnercatalyst.fortis.spark.transforms.topic.{Blacklist, KeywordExtractor}
 
 /**
   * Provides default analysis method implementations for a concrete [[Analyzer]].
@@ -19,6 +19,7 @@ private[analyzer] object AnalysisDefaults {
     with EnableLocation[T]
     with EnableEntity[T]
     with EnableLanguage[T]
+    with FilterBlacklist[T]
     with EnableSentiment[T] {
     this: Analyzer[T] =>
   }
@@ -57,6 +58,13 @@ private[analyzer] object AnalysisDefaults {
     this: Analyzer[T] =>
     override def detectSentiment(details: ExtendedDetails[T], sentimentDetector: SentimentDetector): List[Double] = {
       sentimentDetector.detectSentiment(details.body).toList
+    }
+  }
+
+  trait FilterBlacklist[T] {
+    this: Analyzer[T] =>
+    override def hasBlacklistedTerms(details: ExtendedDetails[T], blacklist: Blacklist): Boolean = {
+      blacklist.matches(details.body) || blacklist.matches(details.title)
     }
   }
 }

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/analyzer/Analyzer.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/analyzer/Analyzer.scala
@@ -6,12 +6,13 @@ import com.microsoft.partnercatalyst.fortis.spark.transforms.language.LanguageDe
 import com.microsoft.partnercatalyst.fortis.spark.transforms.locations.LocationsExtractor
 import com.microsoft.partnercatalyst.fortis.spark.transforms.people.PeopleRecognizer
 import com.microsoft.partnercatalyst.fortis.spark.transforms.sentiment.SentimentDetector
-import com.microsoft.partnercatalyst.fortis.spark.transforms.topic.KeywordExtractor
+import com.microsoft.partnercatalyst.fortis.spark.transforms.topic.{Blacklist, KeywordExtractor}
 
 trait Analyzer[T] {
   type LocationFetcher = (Double, Double) => Iterable[Location]
 
   def toSchema(item: T, locationFetcher: LocationFetcher, imageAnalyzer: ImageAnalyzer): ExtendedDetails[T]
+  def hasBlacklistedTerms(details: ExtendedDetails[T], blacklist: Blacklist): Boolean
   def extractKeywords(details: ExtendedDetails[T], keywordExtractor: KeywordExtractor): List[Tag]
   def extractLocations(details: ExtendedDetails[T], locationsExtractor: LocationsExtractor): List[Location]
   def extractEntities(details: ExtendedDetails[T], peopleRecognizer: PeopleRecognizer): List[Tag]

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/analyzer/InstagramAnalyzer.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/analyzer/InstagramAnalyzer.scala
@@ -12,7 +12,7 @@ import com.microsoft.partnercatalyst.fortis.spark.transforms.people.PeopleRecogn
 import com.microsoft.partnercatalyst.fortis.spark.transforms.sentiment.SentimentDetector
 
 class InstagramAnalyzer extends Analyzer[InstagramItem]
-  with AnalysisDefaults.FilterBlacklist[InstagramItem]
+  with AnalysisDefaults.EnableBlacklist[InstagramItem]
   with AnalysisDefaults.EnableKeyword[InstagramItem] {
   override def toSchema(item: InstagramItem, locationFetcher: LocationFetcher, imageAnalyzer: ImageAnalyzer): ExtendedDetails[InstagramItem] = {
     val imageAnalysis = imageAnalyzer.analyze(item.images.standard_resolution.url)

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/analyzer/InstagramAnalyzer.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/analyzer/InstagramAnalyzer.scala
@@ -12,6 +12,7 @@ import com.microsoft.partnercatalyst.fortis.spark.transforms.people.PeopleRecogn
 import com.microsoft.partnercatalyst.fortis.spark.transforms.sentiment.SentimentDetector
 
 class InstagramAnalyzer extends Analyzer[InstagramItem]
+  with AnalysisDefaults.FilterBlacklist[InstagramItem]
   with AnalysisDefaults.EnableKeyword[InstagramItem] {
   override def toSchema(item: InstagramItem, locationFetcher: LocationFetcher, imageAnalyzer: ImageAnalyzer): ExtendedDetails[InstagramItem] = {
     val imageAnalysis = imageAnalyzer.analyze(item.images.standard_resolution.url)

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/transforms/nlp/Tokenizer.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/transforms/nlp/Tokenizer.scala
@@ -4,6 +4,10 @@ object Tokenizer {
   @transient private lazy val wordTokenizer = """\b""".r
 
   def apply(sentence: String): Seq[String] = {
+    if (sentence.isEmpty) {
+      return Seq()
+    }
+
     wordTokenizer.split(sentence).toSeq
   }
 }

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/transforms/topic/Blacklist.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/transforms/topic/Blacklist.scala
@@ -1,0 +1,10 @@
+package com.microsoft.partnercatalyst.fortis.spark.transforms.topic
+
+import com.microsoft.partnercatalyst.fortis.spark.transforms.nlp.Tokenizer
+
+class Blacklist(blacklist: Seq[Set[String]]) {
+  def matches(text: String): Boolean = {
+    val tokens = Tokenizer(text).toSet
+    blacklist.exists(terms => terms.forall(tokens.contains))
+  }
+}

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/transforms/topic/Blacklist.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/transforms/topic/Blacklist.scala
@@ -4,6 +4,10 @@ import com.microsoft.partnercatalyst.fortis.spark.transforms.nlp.Tokenizer
 
 class Blacklist(blacklist: Seq[Set[String]]) {
   def matches(text: String): Boolean = {
+    if (text.isEmpty) {
+      return false
+    }
+
     val tokens = Tokenizer(text).toSet
     blacklist.exists(terms => terms.forall(tokens.contains))
   }

--- a/src/test/scala/com/microsoft/partnercatalyst/fortis/spark/transforms/nlp/TokenizerSpec.scala
+++ b/src/test/scala/com/microsoft/partnercatalyst/fortis/spark/transforms/nlp/TokenizerSpec.scala
@@ -14,4 +14,8 @@ class TokenizerSpec extends FlatSpec {
   it should "handle non-standard whitespace" in {
     assert(Tokenizer("foo\u2000bar\u00a0baz") == Seq("foo", "\u2000", "bar", "\u00a0", "baz"))
   }
+
+  it should "handle empty inputs" in {
+    assert(Tokenizer("") == Seq())
+  }
 }

--- a/src/test/scala/com/microsoft/partnercatalyst/fortis/spark/transforms/topic/BlacklistSpec.scala
+++ b/src/test/scala/com/microsoft/partnercatalyst/fortis/spark/transforms/topic/BlacklistSpec.scala
@@ -20,4 +20,9 @@ class BlacklistSpec extends FlatSpec {
     assert(blacklist.matches("a b pear c"))
     assert(blacklist.matches("bar baz foo"))
   }
+
+  it should "handle the empty string" in {
+    val blacklist = new Blacklist(Seq(Set("foo", "bar"), Set("pear")))
+    assert(!blacklist.matches(""))
+  }
 }

--- a/src/test/scala/com/microsoft/partnercatalyst/fortis/spark/transforms/topic/BlacklistSpec.scala
+++ b/src/test/scala/com/microsoft/partnercatalyst/fortis/spark/transforms/topic/BlacklistSpec.scala
@@ -1,0 +1,23 @@
+package com.microsoft.partnercatalyst.fortis.spark.transforms.topic
+
+import org.scalatest.FlatSpec
+
+class BlacklistSpec extends FlatSpec {
+  "The blacklist" should "match matching text" in {
+    val blacklist = new Blacklist(Seq(Set("foo")))
+    assert(blacklist.matches("foo bar"))
+    assert(!blacklist.matches("bar baz"))
+  }
+
+  it should "match conjunctions" in {
+    val blacklist = new Blacklist(Seq(Set("foo", "bar")))
+    assert(blacklist.matches("bar baz foo"))
+    assert(!blacklist.matches("bar baz"))
+  }
+
+  it should "match any conjunctions" in {
+    val blacklist = new Blacklist(Seq(Set("foo", "bar"), Set("pear")))
+    assert(blacklist.matches("a b pear c"))
+    assert(blacklist.matches("bar baz foo"))
+  }
+}


### PR DESCRIPTION
Built without using the keyword extractor so that we can offer more predictable behavior to the user: events will only get filtered out if tokens match exactly what the user specified.

Resolves #34 