### PR TITLE
Deploy fat jar to Azure via Travis on tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 dist:
   trusty
 
+sudo:
+  required
+
 language:
   scala
 
@@ -12,3 +15,6 @@ scala:
 
 script:
   - .travis/ci.sh
+
+after_success:
+  - .travis/publish.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,5 @@ jdk:
 scala:
   - 2.11.7
 
-env:
-  - TARGET=test
-
 script:
-  - sbt ++$TRAVIS_SCALA_VERSION $TARGET
+  - .travis/ci.sh

--- a/.travis/ci.sh
+++ b/.travis/ci.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+sbt ++${TRAVIS_SCALA_VERSION} test

--- a/.travis/publish.sh
+++ b/.travis/publish.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly tag="${TRAVIS_TAG}"
+readonly blobaccount="${DEPLOY_BLOB_ACCOUNT_NAME}"
+readonly blobkey="${DEPLOY_BLOB_ACCOUNT_KEY}"
+readonly blobcontainer="${DEPLOY_BLOB_CONTAINER}"
+readonly blobname="fortis-${tag}.jar"
+
+log() {
+  echo "$@" >&2
+}
+
+check_preconditions() {
+  if [ -z "${tag}" ]; then
+    log "Build is not a tag, skipping publish"
+    exit 0
+  fi
+  if [ -z "${blobaccount}" ] || [ -z "${blobkey}" ] || [ -z "${blobcontainer}" ]; then
+    log "Azure blob connection is not set, unable to publish builds"
+    exit 1
+  fi
+}
+
+install_azure_cli() {
+  curl -sL https://deb.nodesource.com/setup_6.x | sudo -E bash -
+  sudo apt-get update
+  sudo apt-get install -y -qq nodejs
+  sudo npm install -g npm
+  sudo npm install -g azure-cli
+}
+
+create_fat_jar() {
+  sbt ++${TRAVIS_SCALA_VERSION} assembly
+}
+
+publish_fat_jar() {
+  local fatjar="$(find target -name 'project-fortis-spark-assembly-*.jar' -print -quit)"
+  if [ -z "${fatjar}" ] || [ ! -f "${fatjar}" ]; then
+    log "Unable to locate fat jar"
+    exit 1
+  fi
+
+  AZURE_NON_INTERACTIVE_MODE=1 \
+  azure storage blob upload \
+  --quiet \
+  --account-name "${blobaccount}" \
+  --account-key "${blobkey}" \
+  --file "${fatjar}" \
+  --container "${blobcontainer}" \
+  --blob "${blobname}"
+}
+
+check_preconditions
+install_azure_cli
+create_fat_jar
+publish_fat_jar


### PR DESCRIPTION
After merging this pull request, whenever we push a tag to Github, Travis will as part of the CI automatically build a fat jar that contains project-fortis-spark and all of its dependencies and then upload that jar to a public Azure Blob storage from where our cluster launching script can pick up the jar and pass it to spark-submit.

Sample run:
- [tag](https://github.com/CatalystCode/project-fortis-spark/tree/travis-publish-demo)
- [build](https://travis-ci.org/CatalystCode/project-fortis-spark/builds/247745513)
- [jar](https://fortiscentral.blob.core.windows.net/jars/fortis-travis-publish-demo)

This process takes about 5 minutes to run, so we could even consider running it on every Travis run (not just on tags) and name the created jars by their commit hash. This is a trivial one-line change to the `.travis/publish.sh` script so just let me know if you'd like that option.

Another thing that we can implement is to upload a second copy of the jar to a name like `fortis-latest.jar` so that the deployment script can always pick up the latest jar without having to be modified. Thoughts?

Resolves #31 