### PR TITLE
Allow environment to override http/https for apis

### DIFF
--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/Constants.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/Constants.scala
@@ -14,5 +14,6 @@ object Constants {
     val FeatureServiceHost = "FORTIS_FEATURE_SERVICE_HOST"
     val OxfordVisionToken= "OXFORD_VISION_TOKEN"
     val OxfordLanguageToken = "OXFORD_LANGUAGE_TOKEN"
+    val BlobHost = "FORTIS_BLOB_HOST"
   }
 }

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/ProjectFortis.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/ProjectFortis.scala
@@ -24,6 +24,7 @@ object ProjectFortis extends App {
     val featureServiceHost = envOrFail(Constants.Env.FeatureServiceHost)
     val oxfordLanguageToken = envOrFail(Constants.Env.OxfordLanguageToken)
     val oxfordVisionToken = envOrFail(Constants.Env.OxfordVisionToken)
+    val blobHost = envOrElse(Constants.Env.BlobHost, "https://fortiscentral.blob.core.windows.net")
 
     val appInsightsKey = envOrNone(Constants.Env.AppInsightsKey)
     val modelsDir = envOrNone(Constants.Env.LanguageModelDir)

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/Settings.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/Settings.scala
@@ -5,6 +5,7 @@ trait Settings {
   val featureServiceHost: String
   val oxfordLanguageToken: String
   val oxfordVisionToken: String
+  val blobHost: String
   val appInsightsKey: Option[String]
   val modelsDir: Option[String]
 }

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/transforms/image/ImageAnalyzer.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/transforms/image/ImageAnalyzer.scala
@@ -6,7 +6,7 @@ import net.liftweb.json
 
 import scalaj.http.Http
 
-case class ImageAnalysisAuth(key: String, apiHost: String = "westus.api.cognitive.microsoft.com")
+case class ImageAnalysisAuth(key: String, apiHost: String = "https://westus.api.cognitive.microsoft.com")
 
 @SerialVersionUID(100L)
 class ImageAnalyzer(auth: ImageAnalysisAuth, featureServiceClient: FeatureServiceClient) extends Serializable {
@@ -17,7 +17,7 @@ class ImageAnalyzer(auth: ImageAnalysisAuth, featureServiceClient: FeatureServic
   }
 
   protected def callCognitiveServices(requestBody: String): String = {
-    Http(s"https://${auth.apiHost}/vision/v1.0/analyze")
+    Http(s"${auth.apiHost}/vision/v1.0/analyze")
       .params(
         "details" -> "Celebrities,Landmarks",
         "visualFeatures" -> "Categories,Tags,Description,Faces")

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/transforms/language/LanguageDetector.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/transforms/language/LanguageDetector.scala
@@ -4,7 +4,7 @@ import net.liftweb.json
 
 import scalaj.http.Http
 
-case class LanguageDetectorAuth(key: String, apiHost: String = "westus.api.cognitive.microsoft.com")
+case class LanguageDetectorAuth(key: String, apiHost: String = "https://westus.api.cognitive.microsoft.com")
 
 @SerialVersionUID(100L)
 class LanguageDetector(
@@ -24,7 +24,7 @@ class LanguageDetector(
   }
 
   protected def callCognitiveServices(requestBody: String): String = {
-    Http(s"https://${auth.apiHost}/text/analytics/v2.0/languages")
+    Http(s"${auth.apiHost}/text/analytics/v2.0/languages")
       .params(
         "numberOfLanguagesToDetect" -> "1")
       .headers(

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/transforms/locations/client/FeatureServiceClient.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/transforms/locations/client/FeatureServiceClient.scala
@@ -40,17 +40,17 @@ class FeatureServiceClient(host: String) extends Serializable with Loggable {
   }
 
   protected def fetchBboxResponse(geofence: Geofence): Try[String] = {
-    val fetch = s"http://$host/features/bbox/${geofence.north}/${geofence.west}/${geofence.south}/${geofence.east}"
+    val fetch = s"$host/features/bbox/${geofence.north}/${geofence.west}/${geofence.south}/${geofence.east}"
     fetchResponse(fetch)
   }
 
   protected def fetchPointResponse(latitude: Double, longitude: Double): Try[String] = {
-    val fetch = s"http://$host/features/point/$latitude/$longitude"
+    val fetch = s"$host/features/point/$latitude/$longitude"
     fetchResponse(fetch)
   }
 
   protected def fetchNameResponse(names: Iterable[String]): Try[String] = {
-    val fetch = s"http://$host/features/name/${names.mkString(",")}"
+    val fetch = s"$host/features/name/${names.mkString(",")}"
     fetchResponse(fetch)
   }
 

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/transforms/sentiment/CognitiveServicesSentimentDetector.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/transforms/sentiment/CognitiveServicesSentimentDetector.scala
@@ -4,7 +4,7 @@ import net.liftweb.json
 
 import scalaj.http.Http
 
-case class SentimentDetectorAuth(key: String, apiHost: String = "westus.api.cognitive.microsoft.com")
+case class SentimentDetectorAuth(key: String, apiHost: String = "https://westus.api.cognitive.microsoft.com")
 
 @SerialVersionUID(100L)
 class CognitiveServicesSentimentDetector(
@@ -20,7 +20,7 @@ class CognitiveServicesSentimentDetector(
   }
 
   protected def callCognitiveServices(requestBody: String): String = {
-    Http(s"https://${auth.apiHost}/text/analytics/v2.0/sentiment")
+    Http(s"${auth.apiHost}/text/analytics/v2.0/sentiment")
       .headers(
         "Content-Type" -> "application/json",
         "Ocp-Apim-Subscription-Key" -> auth.key)


### PR DESCRIPTION
As per standup today: environment variables should be able to override whether we talk to services via http or https.