### PR TITLE
Rename Host to UrlBase

### DIFF
--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/Constants.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/Constants.scala
@@ -11,9 +11,9 @@ object Constants {
     val HighlyAvailableProgressDir = "HA_PROGRESS_DIR"
     val AppInsightsKey = "FORTIS_APPINSIGHTS_IKEY"
     val LanguageModelDir = "FORTIS_MODELS_DIRECTORY"
-    val FeatureServiceHost = "FORTIS_FEATURE_SERVICE_HOST"
+    val FeatureServiceUrlBase = "FORTIS_FEATURE_SERVICE_HOST"
     val OxfordVisionToken= "OXFORD_VISION_TOKEN"
     val OxfordLanguageToken = "OXFORD_LANGUAGE_TOKEN"
-    val BlobHost = "FORTIS_BLOB_HOST"
+    val BlobUrlBase = "FORTIS_BLOB_HOST"
   }
 }

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/Constants.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/Constants.scala
@@ -14,6 +14,6 @@ object Constants {
     val FeatureServiceUrlBase = "FORTIS_FEATURE_SERVICE_HOST"
     val OxfordVisionToken= "OXFORD_VISION_TOKEN"
     val OxfordLanguageToken = "OXFORD_LANGUAGE_TOKEN"
-    val BlobUrlBase = "FORTIS_BLOB_HOST"
+    val BlobUrlBase = "FORTIS_CENTRAL_ASSETS_HOST"
   }
 }

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/Pipeline.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/Pipeline.scala
@@ -31,10 +31,10 @@ object Pipeline {
       // broadcast changes across the Spark cluster.
 
       val geofence = Geofence(north = 49.6185146245, west = -124.9578052195, south = 46.8691952854, east = -121.0945042053)
-      val entityModelsProvider = new ZipModelsProvider(language => s"${Settings.blobHost}/opener/opener-$language.zip", Settings.modelsDir)
-      val sentimentModelsProvider = new ZipModelsProvider(language => s"${Settings.blobHost}/sentiment/sentiment-$language.zip", Settings.modelsDir)
+      val entityModelsProvider = new ZipModelsProvider(language => s"${Settings.blobUrlBase}/opener/opener-$language.zip", Settings.modelsDir)
+      val sentimentModelsProvider = new ZipModelsProvider(language => s"${Settings.blobUrlBase}/sentiment/sentiment-$language.zip", Settings.modelsDir)
 
-      val featureServiceClient = new FeatureServiceClient(Settings.featureServiceHost)
+      val featureServiceClient = new FeatureServiceClient(Settings.featureServiceUrlBase)
       val locationsExtractorFactory = new LocationsExtractorFactory(featureServiceClient, geofence).buildLookup()
       val locationFetcher = locationsExtractorFactory.fetch _
       val blacklist = new Blacklist(Seq(Set("Trump", "Hilary")))

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/ProjectFortis.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/ProjectFortis.scala
@@ -21,10 +21,10 @@ object ProjectFortis extends App {
     import scala.util.Properties.envOrNone
 
     val progressDir = envOrFail(Constants.Env.HighlyAvailableProgressDir)
-    val featureServiceHost = envOrFail(Constants.Env.FeatureServiceHost)
+    val featureServiceUrlBase = envOrFail(Constants.Env.FeatureServiceUrlBase)
     val oxfordLanguageToken = envOrFail(Constants.Env.OxfordLanguageToken)
     val oxfordVisionToken = envOrFail(Constants.Env.OxfordVisionToken)
-    val blobHost = envOrElse(Constants.Env.BlobHost, "https://fortiscentral.blob.core.windows.net")
+    val blobUrlBase = envOrElse(Constants.Env.BlobUrlBase, "https://fortiscentral.blob.core.windows.net")
 
     val appInsightsKey = envOrNone(Constants.Env.AppInsightsKey)
     val modelsDir = envOrNone(Constants.Env.LanguageModelDir)

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/Settings.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/Settings.scala
@@ -2,10 +2,10 @@ package com.microsoft.partnercatalyst.fortis.spark
 
 trait Settings {
   val progressDir: String
-  val featureServiceHost: String
+  val featureServiceUrlBase: String
   val oxfordLanguageToken: String
   val oxfordVisionToken: String
-  val blobHost: String
+  val blobUrlBase: String
   val appInsightsKey: Option[String]
   val modelsDir: Option[String]
 }

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/transforms/image/ImageAnalyzer.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/transforms/image/ImageAnalyzer.scala
@@ -6,7 +6,7 @@ import net.liftweb.json
 
 import scalaj.http.Http
 
-case class ImageAnalysisAuth(key: String, apiHost: String = "https://westus.api.cognitive.microsoft.com")
+case class ImageAnalysisAuth(key: String, apiUrlBase: String = "https://westus.api.cognitive.microsoft.com")
 
 @SerialVersionUID(100L)
 class ImageAnalyzer(auth: ImageAnalysisAuth, featureServiceClient: FeatureServiceClient) extends Serializable {
@@ -17,7 +17,7 @@ class ImageAnalyzer(auth: ImageAnalysisAuth, featureServiceClient: FeatureServic
   }
 
   protected def callCognitiveServices(requestBody: String): String = {
-    Http(s"${auth.apiHost}/vision/v1.0/analyze")
+    Http(s"${auth.apiUrlBase}/vision/v1.0/analyze")
       .params(
         "details" -> "Celebrities,Landmarks",
         "visualFeatures" -> "Categories,Tags,Description,Faces")

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/transforms/language/LanguageDetector.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/transforms/language/LanguageDetector.scala
@@ -4,7 +4,7 @@ import net.liftweb.json
 
 import scalaj.http.Http
 
-case class LanguageDetectorAuth(key: String, apiHost: String = "https://westus.api.cognitive.microsoft.com")
+case class LanguageDetectorAuth(key: String, apiUrlBase: String = "https://westus.api.cognitive.microsoft.com")
 
 @SerialVersionUID(100L)
 class LanguageDetector(
@@ -24,7 +24,7 @@ class LanguageDetector(
   }
 
   protected def callCognitiveServices(requestBody: String): String = {
-    Http(s"${auth.apiHost}/text/analytics/v2.0/languages")
+    Http(s"${auth.apiUrlBase}/text/analytics/v2.0/languages")
       .params(
         "numberOfLanguagesToDetect" -> "1")
       .headers(

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/transforms/locations/client/FeatureServiceClient.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/transforms/locations/client/FeatureServiceClient.scala
@@ -9,7 +9,7 @@ import scala.io.Source
 import scala.util.{Failure, Success, Try}
 
 @SerialVersionUID(100L)
-class FeatureServiceClient(host: String) extends Serializable with Loggable {
+class FeatureServiceClient(apiUrlBase: String) extends Serializable with Loggable {
   def bbox(geofence: Geofence): Iterable[FeatureServiceFeature] = {
     unpack(fetchBboxResponse(geofence), "bbox")
   }
@@ -40,17 +40,17 @@ class FeatureServiceClient(host: String) extends Serializable with Loggable {
   }
 
   protected def fetchBboxResponse(geofence: Geofence): Try[String] = {
-    val fetch = s"$host/features/bbox/${geofence.north}/${geofence.west}/${geofence.south}/${geofence.east}"
+    val fetch = s"$apiUrlBase/features/bbox/${geofence.north}/${geofence.west}/${geofence.south}/${geofence.east}"
     fetchResponse(fetch)
   }
 
   protected def fetchPointResponse(latitude: Double, longitude: Double): Try[String] = {
-    val fetch = s"$host/features/point/$latitude/$longitude"
+    val fetch = s"$apiUrlBase/features/point/$latitude/$longitude"
     fetchResponse(fetch)
   }
 
   protected def fetchNameResponse(names: Iterable[String]): Try[String] = {
-    val fetch = s"$host/features/name/${names.mkString(",")}"
+    val fetch = s"$apiUrlBase/features/name/${names.mkString(",")}"
     fetchResponse(fetch)
   }
 

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/transforms/sentiment/CognitiveServicesSentimentDetector.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/transforms/sentiment/CognitiveServicesSentimentDetector.scala
@@ -4,7 +4,7 @@ import net.liftweb.json
 
 import scalaj.http.Http
 
-case class SentimentDetectorAuth(key: String, apiHost: String = "https://westus.api.cognitive.microsoft.com")
+case class SentimentDetectorAuth(key: String, apiUrlBase: String = "https://westus.api.cognitive.microsoft.com")
 
 @SerialVersionUID(100L)
 class CognitiveServicesSentimentDetector(
@@ -20,7 +20,7 @@ class CognitiveServicesSentimentDetector(
   }
 
   protected def callCognitiveServices(requestBody: String): String = {
-    Http(s"${auth.apiHost}/text/analytics/v2.0/sentiment")
+    Http(s"${auth.apiUrlBase}/text/analytics/v2.0/sentiment")
       .headers(
         "Content-Type" -> "application/json",
         "Ocp-Apim-Subscription-Key" -> auth.key)

--- a/src/test/scala/com/microsoft/partnercatalyst/fortis/spark/transforms/locations/LocationsExtractorSpec.scala
+++ b/src/test/scala/com/microsoft/partnercatalyst/fortis/spark/transforms/locations/LocationsExtractorSpec.scala
@@ -22,7 +22,7 @@ class TestLocationsExtractorFactory(client: FeatureServiceClient) extends Locati
   def getLookup: Map[String, Set[String]] = lookup
 }
 
-class TestFeatureServiceClient(givenBbox: Seq[FeatureServiceFeature], givenPoint: Seq[FeatureServiceFeature]) extends FeatureServiceClient("test-host") {
+class TestFeatureServiceClient(givenBbox: Seq[FeatureServiceFeature], givenPoint: Seq[FeatureServiceFeature]) extends FeatureServiceClient("http://some/test/url") {
   override def bbox(geofence: Geofence): Iterable[FeatureServiceFeature] = givenBbox
   override def point(latitude: Double, longitude: Double): Iterable[FeatureServiceFeature] = givenPoint
 }

--- a/src/test/scala/com/microsoft/partnercatalyst/fortis/spark/transforms/locations/client/FeatureServiceClientSpec.scala
+++ b/src/test/scala/com/microsoft/partnercatalyst/fortis/spark/transforms/locations/client/FeatureServiceClientSpec.scala
@@ -6,7 +6,7 @@ import org.scalatest.FlatSpec
 
 import scala.util.Try
 
-class TestFeatureServiceClient(bboxResponse: String) extends FeatureServiceClient(host = "unittest") {
+class TestFeatureServiceClient(bboxResponse: String) extends FeatureServiceClient(apiUrlBase = "unittest") {
   override def fetchBboxResponse(geofence: Geofence): Try[String] = Try(bboxResponse)
 }
 


### PR DESCRIPTION
As per @jcjimenez's [comment](https://github.com/CatalystCode/project-fortis-services/pull/44#discussion_r125698379), renaming all `host` references to `urlBase` to avoid confusion.

No functional change.