### PR TITLE
Add missing Serializable on InstagramAnalyzer and Blacklist

### DIFF
--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/analyzer/InstagramAnalyzer.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/analyzer/InstagramAnalyzer.scala
@@ -11,7 +11,8 @@ import com.microsoft.partnercatalyst.fortis.spark.transforms.locations.Locations
 import com.microsoft.partnercatalyst.fortis.spark.transforms.people.PeopleRecognizer
 import com.microsoft.partnercatalyst.fortis.spark.transforms.sentiment.SentimentDetector
 
-class InstagramAnalyzer extends Analyzer[InstagramItem]
+@SerialVersionUID(100L)
+class InstagramAnalyzer extends Analyzer[InstagramItem] with Serializable
   with AnalysisDefaults.EnableBlacklist[InstagramItem]
   with AnalysisDefaults.EnableKeyword[InstagramItem] {
   override def toSchema(item: InstagramItem, locationFetcher: LocationFetcher, imageAnalyzer: ImageAnalyzer): ExtendedDetails[InstagramItem] = {

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/transforms/topic/Blacklist.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/transforms/topic/Blacklist.scala
@@ -2,7 +2,8 @@ package com.microsoft.partnercatalyst.fortis.spark.transforms.topic
 
 import com.microsoft.partnercatalyst.fortis.spark.transforms.nlp.Tokenizer
 
-class Blacklist(blacklist: Seq[Set[String]]) {
+@SerialVersionUID(100L)
+class Blacklist(blacklist: Seq[Set[String]]) extends Serializable {
   def matches(text: String): Boolean = {
     if (text.isEmpty) {
       return false


### PR DESCRIPTION
No functional changes.

After adding these interfaces, checkpointing/recovery of our DStream graph appears to be working.