### PR TITLE
Implement Cassandra configuration manager

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -43,6 +43,7 @@ libraryDependencies ++= Seq(
   "org.apache.kafka" %% "kafka" % "0.10.2.1",
   "net.liftweb" %% "lift-json" % "3.0.1",
   "org.scalaj" %% "scalaj-http" % "2.3.0",
+  "org.scala-lang.modules" %% "scala-java8-compat" % "0.8.0",
   "net.lingala.zip4j" % "zip4j" % "1.3.2",
   "eus.ixa" % "ixa-pipe-pos" % "1.5.2",
   "eus.ixa" % "ixa-pipe-tok" % "1.8.6",

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/Pipeline.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/Pipeline.scala
@@ -27,7 +27,7 @@ object Pipeline {
     transformContextProvider: TransformContextProvider,
     configurationManager: ConfigurationManager
   ): Option[DStream[FortisEvent]] = {
-    val configs = configurationManager.fetchConnectorConfigs(name)
+    val configs = configurationManager.fetchConnectorConfigs(ssc.sparkContext, name)
     val sourceStream = streamProvider.buildStream[T](ssc, configs)
 
     val entityModelsProvider = new ZipModelsProvider(language => s"${Settings.blobUrlBase}/opener/opener-$language.zip", Settings.modelsDir)

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/ProjectFortis.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/ProjectFortis.scala
@@ -106,7 +106,7 @@ object ProjectFortis extends App {
     */
   @SerialVersionUID(100L)
   private object DummyConfigurationManager extends ConfigurationManager with Serializable {
-    override def fetchConnectorConfigs(pipeline: String): List[ConnectorConfig] = {
+    override def fetchConnectorConfigs(sparkContext: SparkContext, pipeline: String): List[ConnectorConfig] = {
       // The key is the name of the pipeline and the value is a list of connector configs whose streams should comprise it.
       Map[String, List[ConnectorConfig]](
         "instagram" -> List(
@@ -225,7 +225,7 @@ object ProjectFortis extends App {
       )(pipeline)
     }
 
-    override def fetchSiteSettings(): SiteSettings = SiteSettings(
+    override def fetchSiteSettings(sparkContext: SparkContext): SiteSettings = SiteSettings(
       id = null,
       siteName = "",
       geofence = Geofence(north = 49.6185146245, west = -124.9578052195, south = 46.8691952854, east = -121.0945042053),
@@ -237,17 +237,15 @@ object ProjectFortis extends App {
       cogSpeechSvcToken = System.getenv("OXFORD_SPEECH_TOKEN"),
       cogTextSvcToken = Settings.oxfordLanguageToken,
       cogVisionSvcToken = Settings.oxfordVisionToken,
-      insertionTime = ""
+      insertionTime = 0L
     )
 
-    override def fetchTrustedSources(connector: String): List[String] = ???
-
-    override def fetchWatchlist(): Map[String, List[String]] =
+    override def fetchWatchlist(sparkContext: SparkContext): Map[String, Seq[String]] =
       Map(
         "en" -> List("Ariana")
       )
 
-    override def fetchBlacklist(): List[BlacklistedTerm] =
+    override def fetchBlacklist(sparkContext: SparkContext): Seq[BlacklistedTerm] =
       List(
         BlacklistedTerm(conjunctiveFilter = Set("Trump", "Hilary"))
       )

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/dba/CassandraConfigurationManager.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/dba/CassandraConfigurationManager.scala
@@ -1,0 +1,84 @@
+package com.microsoft.partnercatalyst.fortis.spark.dba
+import java.util.concurrent.ConcurrentHashMap
+
+import com.microsoft.partnercatalyst.fortis.spark.dto.{BlacklistedTerm, Geofence, SiteSettings}
+import com.microsoft.partnercatalyst.fortis.spark.sources.streamprovider.ConnectorConfig
+import org.apache.spark.SparkContext
+import com.datastax.spark.connector._
+import com.microsoft.partnercatalyst.fortis.spark.logging.Loggable
+import scala.compat.java8.FunctionConverters._
+
+@SerialVersionUID(100L)
+class CassandraConfigurationManager extends ConfigurationManager with Serializable with Loggable {
+  // Note: trusted sources are cached for the lifetime of the configuration manager since in order to update them,
+  // streaming must be restarted (and hence the configuration manager would be replaced).
+  private lazy val connectorToTrustedSources = new ConcurrentHashMap[String, Seq[String]]()
+
+  override def fetchConnectorConfigs(sparkContext: SparkContext, pipeline: String): List[ConnectorConfig] = {
+    def fetchTrustedSources(connectorName: String): Seq[String] = {
+      sparkContext.cassandraTable(CassandraSchema.KeyspaceName, CassandraSchema.Table.TrustedSourcesName)
+        .select("externalsourceid")
+        .map(row => row.getString("externalsourceid")).collect()
+    }
+
+    val pipelineConfigRows = sparkContext.cassandraTable[CassandraSchema.Table.Stream](CassandraSchema.KeyspaceName,
+      CassandraSchema.Table.StreamsName).collect()
+
+    pipelineConfigRows.map(stream => {
+      val trustedSources = connectorToTrustedSources.computeIfAbsent(stream.connector, (fetchTrustedSources _).asJava)
+
+      ConnectorConfig(
+        stream.connector,
+        stream.params + ("trustedSources" -> trustedSources)
+      )
+
+    }).toList
+  }
+
+  override def fetchSiteSettings(sparkContext: SparkContext): SiteSettings = {
+    val siteSettingRow = sparkContext.cassandraTable[CassandraSchema.Table.SiteSetting](CassandraSchema.KeyspaceName,
+      CassandraSchema.Table.SiteSettingsName).collect().headOption
+
+    siteSettingRow match {
+      case Some(row) =>
+        SiteSettings(
+          id = row.id,
+          siteName = row.sitename,
+          geofence = Geofence(row.geofence(0), row.geofence(1), row.geofence(2), row.geofence(3)),
+          languages = row.languages,
+          defaultZoom = row.defaultzoom,
+          title = row.title,
+          logo = row.logo,
+          translationSvcToken = row.translationsvctoken,
+          cogSpeechSvcToken = row.cogspeechsvctoken,
+          cogVisionSvcToken = row.cogvisionsvctoken,
+          cogTextSvcToken = row.cogtextsvctoken,
+          insertionTime = row.insertionTime
+        )
+      case None =>
+        val ex = new Exception(s"Table '${CassandraSchema.Table.SiteSettingsName}' must have at least 1 entry.")
+        logFatalError(ex.getMessage, ex)
+        throw ex
+    }
+  }
+
+  override def fetchWatchlist(sparkContext: SparkContext): Map[String, List[String]] = {
+    val langToTermPairRdd = sparkContext.cassandraTable(CassandraSchema.KeyspaceName, CassandraSchema.Table.WatchlistName)
+      .select("lang_code", "topic", "translations")
+      .flatMap(row =>
+        (row.getString("lang_code"), row.getString("topic")) :: row.getMap[String, String]("translations").toList
+      )
+      .mapValues(List(_))
+      .reduceByKey(_ ::: _)
+
+    langToTermPairRdd.collectAsMap().toMap
+  }
+
+  override def fetchBlacklist(sparkContext: SparkContext): Seq[BlacklistedTerm] = {
+    val blacklistRdd = sparkContext.cassandraTable(CassandraSchema.KeyspaceName, CassandraSchema.Table.BlacklistName)
+      .select("conjunctivefilter")
+      .map(row => BlacklistedTerm(row.getList[String]("conjunctivefilter").toSet))
+
+    blacklistRdd.collect()
+  }
+}

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/dba/CassandraConfigurationManager.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/dba/CassandraConfigurationManager.scala
@@ -29,7 +29,11 @@ class CassandraConfigurationManager extends ConfigurationManager with Serializab
 
       ConnectorConfig(
         stream.connector,
-        stream.params + ("trustedSources" -> trustedSources)
+        stream.params +
+          (
+            "trustedSources" -> trustedSources,
+            "streamId" -> stream.streamid
+          )
       )
 
     }).toList

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/dba/CassandraSchema.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/dba/CassandraSchema.scala
@@ -1,0 +1,37 @@
+package com.microsoft.partnercatalyst.fortis.spark.dba
+
+import java.util.UUID
+
+object CassandraSchema {
+  val KeyspaceName = "fortis"
+
+  object Table {
+    val BlacklistName = "blacklist"
+    val WatchlistName = "watchlist"
+    val SiteSettingsName = "sitesettings"
+    val StreamsName = "streams"
+    val TrustedSourcesName = "trustedsources"
+
+    case class SiteSetting(
+      id: UUID,
+      sitename: String,
+      geofence: Seq[Double],
+      languages: Set[String],
+      defaultzoom: Int,
+      title: String,
+      logo: String,
+      translationsvctoken: String,
+      cogspeechsvctoken: String,
+      cogvisionsvctoken: String,
+      cogtextsvctoken: String,
+      insertionTime: Long
+    )
+
+    case class Stream(
+      pipeline: String,
+      streamid: Long,
+      connector: String,
+      params: Map[String, String]
+    )
+  }
+}

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/dba/ConfigurationManager.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/dba/ConfigurationManager.scala
@@ -2,11 +2,12 @@ package com.microsoft.partnercatalyst.fortis.spark.dba
 
 import com.microsoft.partnercatalyst.fortis.spark.dto.{BlacklistedTerm, SiteSettings}
 import com.microsoft.partnercatalyst.fortis.spark.sources.streamprovider.ConnectorConfig
+import org.apache.spark.SparkContext
 
 trait ConfigurationManager {
-  def fetchConnectorConfigs(pipeline: String): List[ConnectorConfig]
-  def fetchSiteSettings(): SiteSettings
-  def fetchTrustedSources(connector: String): List[String]
-  def fetchWatchlist(): Map[String, List[String]]
-  def fetchBlacklist(): List[BlacklistedTerm]
+  def fetchConnectorConfigs(sparkContext: SparkContext, pipeline: String): List[ConnectorConfig]
+  def fetchSiteSettings(sparkContext: SparkContext): SiteSettings
+
+  def fetchWatchlist(sparkContext: SparkContext): Map[String, Seq[String]]
+  def fetchBlacklist(sparkContext: SparkContext): Seq[BlacklistedTerm]
 }

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/dto/SiteSettings.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/dto/SiteSettings.scala
@@ -14,5 +14,5 @@ case class SiteSettings(
   cogSpeechSvcToken: String,
   cogVisionSvcToken: String,
   cogTextSvcToken: String,
-  insertionTime: String
+  insertionTime: Long
 )

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/sources/streamfactories/BingPageStreamFactory.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/sources/streamfactories/BingPageStreamFactory.scala
@@ -9,9 +9,11 @@ import org.apache.spark.streaming.dstream.DStream
 class BingPageStreamFactory extends StreamFactory[BingPost]{
   override def createStream(ssc: StreamingContext): PartialFunction[ConnectorConfig, DStream[BingPost]] = {
     case ConnectorConfig("BingPage", params) =>
-      val auth = BingAuth(params("accessToken"))
-      val searchInstanceId = params("searchInstanceId")
-      val keywords = params("keywords").split('|')
+      import ParameterExtensions._
+
+      val auth = BingAuth(params.getAs[String]("accessToken"))
+      val searchInstanceId = params.getAs[String]("searchInstanceId")
+      val keywords = params.getAs[String]("keywords").split('|')
 
       BingUtils.createPageStream(ssc, auth, searchInstanceId, keywords)
   }

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/sources/streamfactories/EventHubStreamFactory.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/sources/streamfactories/EventHubStreamFactory.scala
@@ -17,22 +17,23 @@ class EventHubStreamFactory[A: ClassTag](identifier: String, adapter: (Array[Byt
 
   override def createStream(streamingContext: StreamingContext): PartialFunction[ConnectorConfig, DStream[A]] = {
     case ConnectorConfig(`identifier`, params) =>
+      import ParameterExtensions._
 
       // Copy adapter ref locally to avoid serializing entire EventHubStreamFactory instance
       val adapter_ = adapter
-      val className_ = getClass.getName
+      val className_ = this.getClass.getName
 
       EventHubsUtils.createDirectStreams(
         streamingContext,
-        params("namespace"),
+        params.getAs[String]("namespace"),
         progressDir,
-        Map(params("name") -> Map(
-          "eventhubs.policyname" -> params("policyName"),
-          "eventhubs.policykey" -> params("policyKey"),
-          "eventhubs.namespace" -> params("namespace"),
-          "eventhubs.name" -> params("name"),
-          "eventhubs.partition.count" -> params("partitionCount"),
-          "eventhubs.consumergroup" -> params("consumerGroup")
+        Map(params.getAs[String]("name") -> Map(
+          "eventhubs.policyname" -> params.getAs[String]("policyName"),
+          "eventhubs.policykey" -> params.getAs[String]("policyKey"),
+          "eventhubs.namespace" -> params.getAs[String]("namespace"),
+          "eventhubs.name" -> params.getAs[String]("name"),
+          "eventhubs.partition.count" -> params.getAs[String]("partitionCount"),
+          "eventhubs.consumergroup" -> params.getAs[String]("consumerGroup")
         ))
       ).map(_.getBytes).flatMap(adapter_(_) match {
         case Success(event) => Some(event)

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/sources/streamfactories/FacebookCommentsStreamFactory.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/sources/streamfactories/FacebookCommentsStreamFactory.scala
@@ -18,12 +18,14 @@ class FacebookCommentStreamFactory extends StreamFactory[FacebookComment] {
     */
   override def createStream(streamingContext: StreamingContext): PartialFunction[ConnectorConfig, DStream[FacebookComment]] = {
     case ConnectorConfig("FacebookComment", params) =>
-      val facebookAuth = FacebookAuth(params("appId"), params("appSecret"), params("accessToken"))
-      val pageIds = Option(params("pageIds")) match {
-        case None => Set()
-        case Some(pageIds) => pageIds.split(DELIMITER).toSet
-      }
+      import ParameterExtensions._
 
-      FacebookUtils.createCommentsStreams(streamingContext, facebookAuth, pageIds.toSet)
+      val facebookAuth = FacebookAuth(
+        params.getAs[String]("appId"),
+        params.getAs[String]("appSecret"),
+        params.getAs[String]("accessToken")
+      )
+
+      FacebookUtils.createCommentsStreams(streamingContext, facebookAuth, params.getTrustedSources.toSet)
   }
 }

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/sources/streamfactories/InstagramLocationStreamFactory.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/sources/streamfactories/InstagramLocationStreamFactory.scala
@@ -16,12 +16,14 @@ class InstagramLocationStreamFactory extends StreamFactory[InstagramItem]{
     */
   override def createStream(streamingContext: StreamingContext): PartialFunction[ConnectorConfig, DStream[InstagramItem]] = {
     case ConnectorConfig("InstagramLocation", params) =>
-      val auth = InstagramAuth(params("authToken"))
+      import ParameterExtensions._
+
+      val auth = InstagramAuth(params.getAs[String]("authToken"))
 
       InstagramUtils.createLocationStream(
         streamingContext,
         auth,
-        latitude = params("latitude").toDouble,
-        longitude = params("longitude").toDouble)
+        latitude = params.getAs[String]("latitude").toDouble,
+        longitude = params.getAs[String]("longitude").toDouble)
   }
 }

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/sources/streamfactories/InstagramTagStreamFactory.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/sources/streamfactories/InstagramTagStreamFactory.scala
@@ -16,8 +16,9 @@ class InstagramTagStreamFactory extends StreamFactory[InstagramItem]{
     */
   override def createStream(streamingContext: StreamingContext): PartialFunction[ConnectorConfig, DStream[InstagramItem]] = {
     case ConnectorConfig("InstagramTag", params) =>
-      val auth = InstagramAuth(params("authToken"))
+      import ParameterExtensions._
 
-      InstagramUtils.createTagStream(streamingContext, auth, params("tag"))
+      val auth = InstagramAuth(params.getAs[String]("authToken"))
+      InstagramUtils.createTagStream(streamingContext, auth, params.getAs[String]("tag"))
   }
 }

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/sources/streamfactories/ParameterExtensions.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/sources/streamfactories/ParameterExtensions.scala
@@ -1,0 +1,8 @@
+package com.microsoft.partnercatalyst.fortis.spark.sources.streamfactories
+
+object ParameterExtensions {
+  implicit class Parameters(val bag: Map[String, Any]) extends AnyVal {
+    def getAs[T](key: String): T = bag(key).asInstanceOf[T]
+    def getTrustedSources: Seq[String] = bag("trustedSources").asInstanceOf[Seq[String]]
+  }
+}

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/sources/streamfactories/RadioStreamFactory.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/sources/streamfactories/RadioStreamFactory.scala
@@ -8,8 +8,15 @@ import org.apache.spark.streaming.dstream.DStream
 class RadioStreamFactory extends StreamFactory[RadioTranscription]{
   override def createStream(ssc: StreamingContext): PartialFunction[ConnectorConfig, DStream[RadioTranscription]] = {
     case ConnectorConfig("Radio", params) =>
-      RadioStreamUtils.createStream(
-        ssc, params("radioUrl"), params("audioType"), params("locale"),
-        params("subscriptionKey"), params("speechType"), params("outputFormat"))
+      import ParameterExtensions._
+
+      RadioStreamUtils.createStream(ssc,
+        params.getAs[String]("radioUrl"),
+        params.getAs[String]("audioType"),
+        params.getAs[String]("locale"),
+        params.getAs[String]("subscriptionKey"),
+        params.getAs[String]("speechType"),
+        params.getAs[String]("outputFormat")
+      )
   }
 }

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/sources/streamfactories/RedditStreamFactory.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/sources/streamfactories/RedditStreamFactory.scala
@@ -9,12 +9,14 @@ import org.apache.spark.streaming.dstream.DStream
 class RedditStreamFactory extends StreamFactory[RedditObject] {
   override def createStream(streamingContext: StreamingContext): PartialFunction[ConnectorConfig, DStream[RedditObject]] = {
     case ConnectorConfig("RedditObject", params) =>
-      val auth = RedditAuth(params("applicationId"), params("applicationSecret"))
-      val keywords = params("keywords").split('|')
+      import ParameterExtensions._
 
-      val subreddit = params.get("subreddit")
-      val searchLimit = params.getOrElse("searchLimit", "25").toInt
-      val searchResultType = Some(params.getOrElse("searchResultType", "link"))
+      val auth = RedditAuth(params.getAs[String]("applicationId"), params.getAs[String]("applicationSecret"))
+      val keywords = params.getAs[String]("keywords").split('|')
+
+      val subreddit = params.get("subreddit").asInstanceOf[Option[String]]
+      val searchLimit = params.getOrElse("searchLimit", "25").asInstanceOf[String].toInt
+      val searchResultType = Some(params.getOrElse("searchResultType", "link").asInstanceOf[String])
       RedditUtils.createPageStream(
         auth,
         keywords.toSeq,

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/sources/streamprovider/ConnectorConfig.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/sources/streamprovider/ConnectorConfig.scala
@@ -1,3 +1,3 @@
 package com.microsoft.partnercatalyst.fortis.spark.sources.streamprovider
 
-case class ConnectorConfig(name: String, parameters: Map[String, String])
+case class ConnectorConfig(name: String, parameters: Map[String, Any])

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/transformcontext/Delta.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/transformcontext/Delta.scala
@@ -15,7 +15,7 @@ import com.microsoft.partnercatalyst.fortis.spark.transforms.topic.KeywordExtrac
 private[transformcontext] class Delta private(
   val siteSettings: Option[SiteSettings],
   val langToKeywordExtractor: Option[Map[String, KeywordExtractor]],
-  val blacklist: Option[List[BlacklistedTerm]],
+  val blacklist: Option[Seq[BlacklistedTerm]],
   val locationsExtractorFactory: Option[LocationsExtractorFactory],
   val imageAnalyzer: Option[ImageAnalyzer],
   val languageDetector: Option[LanguageDetector],
@@ -32,8 +32,8 @@ private[transformcontext] object Delta {
     transformContext: TransformContext,
     featureServiceClient: FeatureServiceClient,
     siteSettings: Option[SiteSettings] = None,
-    langToWatchlist: Option[Map[String, List[String]]] = None,
-    blacklist: Option[List[BlacklistedTerm]] = None): Delta =
+    langToWatchlist: Option[Map[String, Seq[String]]] = None,
+    blacklist: Option[Seq[BlacklistedTerm]] = None): Delta =
   {
     // Note that parameters are call-by-name
     def updatedField[T](isDirty: => Boolean, newVal: => T): Option[T] = {

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/transformcontext/TransformContext.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/transformcontext/TransformContext.scala
@@ -11,7 +11,7 @@ import org.apache.spark.broadcast.Broadcast
 case class TransformContext(
   siteSettings: SiteSettings = null,
   langToKeywordExtractor: Broadcast[Map[String, KeywordExtractor]] = null,
-  blacklist: Broadcast[List[BlacklistedTerm]] = null,
+  blacklist: Broadcast[Seq[BlacklistedTerm]] = null,
   locationsExtractorFactory: Broadcast[LocationsExtractorFactory] = null,
 
   // The following objects have a small serialized forms. Consequently, we don't bother to broadcast them

--- a/src/test/scala/com/microsoft/partnercatalyst/fortis/spark/SparkSpec.scala
+++ b/src/test/scala/com/microsoft/partnercatalyst/fortis/spark/SparkSpec.scala
@@ -26,7 +26,7 @@ class SparkSpec extends FlatSpec with BeforeAndAfter {
   class TestStreamFactory(inputQueues: List[mutable.Queue[RDD[String]]]) extends StreamFactory[String] {
     override def createStream(streamingContext: StreamingContext): PartialFunction[ConnectorConfig, DStream[String]] = {
       case ConnectorConfig(TestStreamFactory.Name, params) =>
-        streamingContext.queueStream[String](inputQueues(params(TestStreamFactory.paramIndex).toInt))
+        streamingContext.queueStream[String](inputQueues(params(TestStreamFactory.paramIndex).asInstanceOf[String].toInt))
     }
   }
 


### PR DESCRIPTION
Implementation of the `ConfigurationManager` interface for Cassandra.

**Summary**
- Cassandra config manager implementation. Uses Spark to perform required manipulations.
- Adds Spark context to configuration manager parameter lists for DB access backed by Spark.
- Changes `ConnectorConfig.parameters` from `Map[String, String]` to `Map[String, Any]`.
- Adds `ParameterExtensions` helper class to simplify reading objects from connector config parameter maps.