### PR TITLE
Telemetry for incoming pipeline events

### DIFF
--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/logging/AppInsightsTelemetry.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/logging/AppInsightsTelemetry.scala
@@ -6,7 +6,7 @@ import java.util.HashMap
 class AppInsightsTelemetry extends FortisTelemetry {
   private val client: TelemetryClient = new TelemetryClient(TelemetryConfiguration.createDefault())
 
-  def logIncomingEventBatch(streamId: String, connectorName: String, batchSize: Int): Unit = {
+  def logIncomingEventBatch(streamId: String, connectorName: String, batchSize: Long): Unit = {
     val properties = new HashMap[String, String](2)
     properties.put("streamId", streamId)
     properties.put("connectorName", connectorName)

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/logging/FortisTelemetry.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/logging/FortisTelemetry.scala
@@ -1,7 +1,7 @@
 package com.microsoft.partnercatalyst.fortis.spark.logging
 
 trait FortisTelemetry {
-  def logIncomingEventBatch(streamId: String, connectorName: String, batchSize: Int)
+  def logIncomingEventBatch(streamId: String, connectorName: String, batchSize: Long)
 }
 
 object FortisTelemetry {

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/sources/streamfactories/BingPageStreamFactory.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/sources/streamfactories/BingPageStreamFactory.scala
@@ -6,15 +6,19 @@ import com.microsoft.partnercatalyst.fortis.spark.sources.streamprovider.{Connec
 import org.apache.spark.streaming.StreamingContext
 import org.apache.spark.streaming.dstream.DStream
 
-class BingPageStreamFactory extends StreamFactory[BingPost]{
-  override def createStream(ssc: StreamingContext): PartialFunction[ConnectorConfig, DStream[BingPost]] = {
-    case ConnectorConfig("BingPage", params) =>
-      import ParameterExtensions._
+class BingPageStreamFactory extends StreamFactoryBase[BingPost]{
+  override protected def canHandle(connectorConfig: ConnectorConfig): Boolean = {
+    connectorConfig.name == "BingPage"
+  }
 
-      val auth = BingAuth(params.getAs[String]("accessToken"))
-      val searchInstanceId = params.getAs[String]("searchInstanceId")
-      val keywords = params.getAs[String]("keywords").split('|')
+  override protected def buildStream(streamingContext: StreamingContext, connectorConfig: ConnectorConfig): DStream[BingPost] = {
+    import ParameterExtensions._
 
-      BingUtils.createPageStream(ssc, auth, searchInstanceId, keywords)
+    val params = connectorConfig.parameters
+    val auth = BingAuth(params.getAs[String]("accessToken"))
+    val searchInstanceId = params.getAs[String]("searchInstanceId")
+    val keywords = params.getAs[String]("keywords").split('|')
+
+    BingUtils.createPageStream(streamingContext, auth, searchInstanceId, keywords)
   }
 }

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/sources/streamfactories/BingPageStreamFactory.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/sources/streamfactories/BingPageStreamFactory.scala
@@ -11,7 +11,7 @@ class BingPageStreamFactory extends StreamFactoryBase[BingPost]{
     connectorConfig.name == "BingPage"
   }
 
-  override protected def buildStream(streamingContext: StreamingContext, connectorConfig: ConnectorConfig): DStream[BingPost] = {
+  override protected def buildStream(ssc: StreamingContext, connectorConfig: ConnectorConfig): DStream[BingPost] = {
     import ParameterExtensions._
 
     val params = connectorConfig.parameters
@@ -19,6 +19,6 @@ class BingPageStreamFactory extends StreamFactoryBase[BingPost]{
     val searchInstanceId = params.getAs[String]("searchInstanceId")
     val keywords = params.getAs[String]("keywords").split('|')
 
-    BingUtils.createPageStream(streamingContext, auth, searchInstanceId, keywords)
+    BingUtils.createPageStream(ssc, auth, searchInstanceId, keywords)
   }
 }

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/sources/streamfactories/EventHubStreamFactory.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/sources/streamfactories/EventHubStreamFactory.scala
@@ -15,10 +15,10 @@ import scala.util.{Failure, Success, Try}
 class EventHubStreamFactory[A: ClassTag](identifier: String, adapter: (Array[Byte]) => Try[A], progressDir: String)
   extends StreamFactoryBase[A] {
   override protected def canHandle(connectorConfig: ConnectorConfig): Boolean = {
-    connectorConfig.name == `identifier`
+    connectorConfig.name == identifier
   }
 
-  override protected def buildStream(streamingContext: StreamingContext, connectorConfig: ConnectorConfig): DStream[A] = {
+  override protected def buildStream(ssc: StreamingContext, connectorConfig: ConnectorConfig): DStream[A] = {
     import ParameterExtensions._
 
     // Copy adapter ref locally to avoid serializing entire EventHubStreamFactory instance
@@ -28,7 +28,7 @@ class EventHubStreamFactory[A: ClassTag](identifier: String, adapter: (Array[Byt
     val params = connectorConfig.parameters
 
     EventHubsUtils.createDirectStreams(
-      streamingContext,
+      ssc,
       params.getAs[String]("namespace"),
       progressDir,
       Map(params.getAs[String]("name") -> Map(

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/sources/streamfactories/FacebookCommentsStreamFactory.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/sources/streamfactories/FacebookCommentsStreamFactory.scala
@@ -6,26 +6,23 @@ import com.microsoft.partnercatalyst.fortis.spark.sources.streamprovider.{Connec
 import org.apache.spark.streaming.StreamingContext
 import org.apache.spark.streaming.dstream.DStream
 
-class FacebookCommentStreamFactory extends StreamFactory[FacebookComment] {
+class FacebookCommentStreamFactory extends StreamFactoryBase[FacebookComment] {
   private val DELIMITER: String = "|"
 
-  /**
-    * Creates a DStream for a given connector config iff the connector config is supported by the stream factory.
-    * The param set allows the streaming context to be curried into the partial function that creates the stream.
-    *
-    * @param streamingContext The Spark Streaming Context
-    * @return A partial function for transforming a connector config
-    */
-  override def createStream(streamingContext: StreamingContext): PartialFunction[ConnectorConfig, DStream[FacebookComment]] = {
-    case ConnectorConfig("FacebookComment", params) =>
-      import ParameterExtensions._
+  override protected def canHandle(connectorConfig: ConnectorConfig): Boolean = {
+    connectorConfig.name == "FacebookComment"
+  }
 
-      val facebookAuth = FacebookAuth(
-        params.getAs[String]("appId"),
-        params.getAs[String]("appSecret"),
-        params.getAs[String]("accessToken")
-      )
+  override protected def buildStream(streamingContext: StreamingContext, connectorConfig: ConnectorConfig): DStream[FacebookComment] = {
+    import ParameterExtensions._
 
-      FacebookUtils.createCommentsStreams(streamingContext, facebookAuth, params.getTrustedSources.toSet)
+    val params = connectorConfig.parameters
+    val facebookAuth = FacebookAuth(
+      params.getAs[String]("appId"),
+      params.getAs[String]("appSecret"),
+      params.getAs[String]("accessToken")
+    )
+
+    FacebookUtils.createCommentsStreams(streamingContext, facebookAuth, params.getTrustedSources.toSet)
   }
 }

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/sources/streamfactories/FacebookCommentsStreamFactory.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/sources/streamfactories/FacebookCommentsStreamFactory.scala
@@ -7,13 +7,11 @@ import org.apache.spark.streaming.StreamingContext
 import org.apache.spark.streaming.dstream.DStream
 
 class FacebookCommentStreamFactory extends StreamFactoryBase[FacebookComment] {
-  private val DELIMITER: String = "|"
-
   override protected def canHandle(connectorConfig: ConnectorConfig): Boolean = {
     connectorConfig.name == "FacebookComment"
   }
 
-  override protected def buildStream(streamingContext: StreamingContext, connectorConfig: ConnectorConfig): DStream[FacebookComment] = {
+  override protected def buildStream(ssc: StreamingContext, connectorConfig: ConnectorConfig): DStream[FacebookComment] = {
     import ParameterExtensions._
 
     val params = connectorConfig.parameters
@@ -23,6 +21,6 @@ class FacebookCommentStreamFactory extends StreamFactoryBase[FacebookComment] {
       params.getAs[String]("accessToken")
     )
 
-    FacebookUtils.createCommentsStreams(streamingContext, facebookAuth, params.getTrustedSources.toSet)
+    FacebookUtils.createCommentsStreams(ssc, facebookAuth, params.getTrustedSources.toSet)
   }
 }

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/sources/streamfactories/FacebookPageStreamFactory.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/sources/streamfactories/FacebookPageStreamFactory.scala
@@ -11,7 +11,7 @@ class FacebookPageStreamFactory extends StreamFactoryBase[FacebookPost] {
     connectorConfig.name == "FacebookPage"
   }
 
-  override protected def buildStream(streamingContext: StreamingContext, connectorConfig: ConnectorConfig): DStream[FacebookPost] = {
+  override protected def buildStream(ssc: StreamingContext, connectorConfig: ConnectorConfig): DStream[FacebookPost] = {
     import ParameterExtensions._
 
     val params = connectorConfig.parameters
@@ -21,6 +21,6 @@ class FacebookPageStreamFactory extends StreamFactoryBase[FacebookPost] {
       params.getAs[String]("accessToken")
     )
 
-    FacebookUtils.createPageStreams(streamingContext, facebookAuth, params.getTrustedSources.toSet)
+    FacebookUtils.createPageStreams(ssc, facebookAuth, params.getTrustedSources.toSet)
   }
 }

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/sources/streamfactories/FacebookPageStreamFactory.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/sources/streamfactories/FacebookPageStreamFactory.scala
@@ -6,24 +6,21 @@ import com.microsoft.partnercatalyst.fortis.spark.sources.streamprovider.{Connec
 import org.apache.spark.streaming.StreamingContext
 import org.apache.spark.streaming.dstream.DStream
 
-class FacebookPageStreamFactory extends StreamFactory[FacebookPost] {
-  /**
-    * Creates a DStream for a given connector config iff the connector config is supported by the stream factory.
-    * The param set allows the streaming context to be curried into the partial function that creates the stream.
-    *
-    * @param streamingContext The Spark Streaming Context
-    * @return A partial function for transforming a connector config
-    */
-  override def createStream(streamingContext: StreamingContext): PartialFunction[ConnectorConfig, DStream[FacebookPost]] = {
-    case ConnectorConfig("FacebookPage", params) =>
-      import ParameterExtensions._
+class FacebookPageStreamFactory extends StreamFactoryBase[FacebookPost] {
+  override protected def canHandle(connectorConfig: ConnectorConfig): Boolean = {
+    connectorConfig.name == "FacebookPage"
+  }
 
-      val facebookAuth = FacebookAuth(
-        params.getAs[String]("appId"),
-        params.getAs[String]("appSecret"),
-        params.getAs[String]("accessToken")
-      )
+  override protected def buildStream(streamingContext: StreamingContext, connectorConfig: ConnectorConfig): DStream[FacebookPost] = {
+    import ParameterExtensions._
 
-      FacebookUtils.createPageStreams(streamingContext, facebookAuth, params.getTrustedSources.toSet)
+    val params = connectorConfig.parameters
+    val facebookAuth = FacebookAuth(
+      params.getAs[String]("appId"),
+      params.getAs[String]("appSecret"),
+      params.getAs[String]("accessToken")
+    )
+
+    FacebookUtils.createPageStreams(streamingContext, facebookAuth, params.getTrustedSources.toSet)
   }
 }

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/sources/streamfactories/InstagramLocationStreamFactory.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/sources/streamfactories/InstagramLocationStreamFactory.scala
@@ -11,14 +11,14 @@ class InstagramLocationStreamFactory extends StreamFactoryBase[InstagramItem]{
     connectorConfig.name == "InstagramLocation"
   }
 
-  override protected def buildStream(streamingContext: StreamingContext, connectorConfig: ConnectorConfig): DStream[InstagramItem] = {
+  override protected def buildStream(ssc: StreamingContext, connectorConfig: ConnectorConfig): DStream[InstagramItem] = {
     import ParameterExtensions._
 
     val params = connectorConfig.parameters
     val auth = InstagramAuth(params.getAs[String]("authToken"))
 
     InstagramUtils.createLocationStream(
-      streamingContext,
+      ssc,
       auth,
       latitude = params.getAs[String]("latitude").toDouble,
       longitude = params.getAs[String]("longitude").toDouble)

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/sources/streamfactories/InstagramLocationStreamFactory.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/sources/streamfactories/InstagramLocationStreamFactory.scala
@@ -6,24 +6,21 @@ import com.microsoft.partnercatalyst.fortis.spark.sources.streamprovider.{Connec
 import org.apache.spark.streaming.StreamingContext
 import org.apache.spark.streaming.dstream.DStream
 
-class InstagramLocationStreamFactory extends StreamFactory[InstagramItem]{
-  /**
-    * Creates a DStream for a given connector config iff the connector config is supported by the stream factory.
-    * The param set allows the streaming context to be curried into the partial function which creates the stream.
-    *
-    * @param streamingContext The Spark Streaming Context
-    * @return A partial function for transforming a connector config
-    */
-  override def createStream(streamingContext: StreamingContext): PartialFunction[ConnectorConfig, DStream[InstagramItem]] = {
-    case ConnectorConfig("InstagramLocation", params) =>
-      import ParameterExtensions._
+class InstagramLocationStreamFactory extends StreamFactoryBase[InstagramItem]{
+  override protected def canHandle(connectorConfig: ConnectorConfig): Boolean = {
+    connectorConfig.name == "InstagramLocation"
+  }
 
-      val auth = InstagramAuth(params.getAs[String]("authToken"))
+  override protected def buildStream(streamingContext: StreamingContext, connectorConfig: ConnectorConfig): DStream[InstagramItem] = {
+    import ParameterExtensions._
 
-      InstagramUtils.createLocationStream(
-        streamingContext,
-        auth,
-        latitude = params.getAs[String]("latitude").toDouble,
-        longitude = params.getAs[String]("longitude").toDouble)
+    val params = connectorConfig.parameters
+    val auth = InstagramAuth(params.getAs[String]("authToken"))
+
+    InstagramUtils.createLocationStream(
+      streamingContext,
+      auth,
+      latitude = params.getAs[String]("latitude").toDouble,
+      longitude = params.getAs[String]("longitude").toDouble)
   }
 }

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/sources/streamfactories/InstagramTagStreamFactory.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/sources/streamfactories/InstagramTagStreamFactory.scala
@@ -6,19 +6,17 @@ import com.microsoft.partnercatalyst.fortis.spark.sources.streamprovider.{Connec
 import org.apache.spark.streaming.StreamingContext
 import org.apache.spark.streaming.dstream.DStream
 
-class InstagramTagStreamFactory extends StreamFactory[InstagramItem]{
-  /**
-    * Creates a DStream for a given connector config iff the connector config is supported by the stream factory.
-    * The param set allows the streaming context to be curried into the partial function which creates the stream.
-    *
-    * @param streamingContext The Spark Streaming Context
-    * @return A partial function for transforming a connector config
-    */
-  override def createStream(streamingContext: StreamingContext): PartialFunction[ConnectorConfig, DStream[InstagramItem]] = {
-    case ConnectorConfig("InstagramTag", params) =>
-      import ParameterExtensions._
+class InstagramTagStreamFactory extends StreamFactoryBase[InstagramItem]{
+  override protected def canHandle(connectorConfig: ConnectorConfig): Boolean = {
+    connectorConfig.name == "InstagramTag"
+  }
 
-      val auth = InstagramAuth(params.getAs[String]("authToken"))
-      InstagramUtils.createTagStream(streamingContext, auth, params.getAs[String]("tag"))
+  override protected def buildStream(streamingContext: StreamingContext, connectorConfig: ConnectorConfig): DStream[InstagramItem] = {
+    import ParameterExtensions._
+
+    val params = connectorConfig.parameters
+    val auth = InstagramAuth(params.getAs[String]("authToken"))
+
+    InstagramUtils.createTagStream(streamingContext, auth, params.getAs[String]("tag"))
   }
 }

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/sources/streamfactories/InstagramTagStreamFactory.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/sources/streamfactories/InstagramTagStreamFactory.scala
@@ -11,12 +11,12 @@ class InstagramTagStreamFactory extends StreamFactoryBase[InstagramItem]{
     connectorConfig.name == "InstagramTag"
   }
 
-  override protected def buildStream(streamingContext: StreamingContext, connectorConfig: ConnectorConfig): DStream[InstagramItem] = {
+  override protected def buildStream(ssc: StreamingContext, connectorConfig: ConnectorConfig): DStream[InstagramItem] = {
     import ParameterExtensions._
 
     val params = connectorConfig.parameters
     val auth = InstagramAuth(params.getAs[String]("authToken"))
 
-    InstagramUtils.createTagStream(streamingContext, auth, params.getAs[String]("tag"))
+    InstagramUtils.createTagStream(ssc, auth, params.getAs[String]("tag"))
   }
 }

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/sources/streamfactories/RadioStreamFactory.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/sources/streamfactories/RadioStreamFactory.scala
@@ -5,18 +5,23 @@ import com.microsoft.partnercatalyst.fortis.spark.sources.streamwrappers.radio.{
 import org.apache.spark.streaming.StreamingContext
 import org.apache.spark.streaming.dstream.DStream
 
-class RadioStreamFactory extends StreamFactory[RadioTranscription]{
-  override def createStream(ssc: StreamingContext): PartialFunction[ConnectorConfig, DStream[RadioTranscription]] = {
-    case ConnectorConfig("Radio", params) =>
-      import ParameterExtensions._
+class RadioStreamFactory extends StreamFactoryBase[RadioTranscription]{
+  override protected def canHandle(connectorConfig: ConnectorConfig): Boolean = {
+    connectorConfig.name == "Radio"
+  }
 
-      RadioStreamUtils.createStream(ssc,
-        params.getAs[String]("radioUrl"),
-        params.getAs[String]("audioType"),
-        params.getAs[String]("locale"),
-        params.getAs[String]("subscriptionKey"),
-        params.getAs[String]("speechType"),
-        params.getAs[String]("outputFormat")
-      )
+  override protected def buildStream(streamingContext: StreamingContext, connectorConfig: ConnectorConfig): DStream[RadioTranscription] = {
+    import ParameterExtensions._
+
+    val params = connectorConfig.parameters
+
+    RadioStreamUtils.createStream(ssc,
+      params.getAs[String]("radioUrl"),
+      params.getAs[String]("audioType"),
+      params.getAs[String]("locale"),
+      params.getAs[String]("subscriptionKey"),
+      params.getAs[String]("speechType"),
+      params.getAs[String]("outputFormat")
+    )
   }
 }

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/sources/streamfactories/RadioStreamFactory.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/sources/streamfactories/RadioStreamFactory.scala
@@ -10,7 +10,7 @@ class RadioStreamFactory extends StreamFactoryBase[RadioTranscription]{
     connectorConfig.name == "Radio"
   }
 
-  override protected def buildStream(streamingContext: StreamingContext, connectorConfig: ConnectorConfig): DStream[RadioTranscription] = {
+  override protected def buildStream(ssc: StreamingContext, connectorConfig: ConnectorConfig): DStream[RadioTranscription] = {
     import ParameterExtensions._
 
     val params = connectorConfig.parameters

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/sources/streamfactories/RedditStreamFactory.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/sources/streamfactories/RedditStreamFactory.scala
@@ -11,7 +11,7 @@ class RedditStreamFactory extends StreamFactoryBase[RedditObject] {
     connectorConfig.name == "RedditObject"
   }
 
-  override protected def buildStream(streamingContext: StreamingContext, connectorConfig: ConnectorConfig): DStream[RedditObject] = {
+  override protected def buildStream(ssc: StreamingContext, connectorConfig: ConnectorConfig): DStream[RedditObject] = {
     import ParameterExtensions._
 
     val params = connectorConfig.parameters
@@ -24,7 +24,7 @@ class RedditStreamFactory extends StreamFactoryBase[RedditObject] {
     RedditUtils.createPageStream(
       auth,
       keywords.toSeq,
-      streamingContext,
+      ssc,
       subredit = subreddit,
       searchLimit = searchLimit,
       searchResultType = searchResultType

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/sources/streamfactories/StreamFactoryBase.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/sources/streamfactories/StreamFactoryBase.scala
@@ -1,0 +1,29 @@
+package com.microsoft.partnercatalyst.fortis.spark.sources.streamfactories
+
+import com.microsoft.partnercatalyst.fortis.spark.logging.FortisTelemetry
+import com.microsoft.partnercatalyst.fortis.spark.sources.streamprovider.{ConnectorConfig, StreamFactory}
+import org.apache.spark.streaming.StreamingContext
+import org.apache.spark.streaming.dstream.DStream
+
+import scala.reflect.ClassTag
+
+abstract class StreamFactoryBase[A: ClassTag] extends StreamFactory[A]{
+  override def createStream(streamingContext: StreamingContext): PartialFunction[ConnectorConfig, DStream[A]] = {
+    case config if canHandle(config) =>
+      val stream = buildStream(streamingContext, config)
+
+      stream.transform(rdd => {
+        rdd.cache()
+        val batchSize = rdd.count().toInt
+        val streamId = config.parameters.get("streamId").get.toString
+        val connectorName = config.name
+        val telemetry = FortisTelemetry.get()
+        telemetry.logIncomingEventBatch(streamId, connectorName, batchSize)
+
+        rdd
+      })
+  }
+
+  protected def canHandle(connectorConfig: ConnectorConfig): Boolean
+  protected def buildStream(streamingContext: StreamingContext, connectorConfig: ConnectorConfig): DStream[A]
+}

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/sources/streamfactories/StreamFactoryBase.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/sources/streamfactories/StreamFactoryBase.scala
@@ -14,7 +14,7 @@ abstract class StreamFactoryBase[A: ClassTag] extends StreamFactory[A]{
 
       stream.transform(rdd => {
         rdd.cache()
-        val batchSize = rdd.count().toInt
+        val batchSize = rdd.count()
         val streamId = config.parameters.get("streamId").get.toString
         val connectorName = config.name
         val telemetry = FortisTelemetry.get()

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/sources/streamfactories/StreamFactoryBase.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/sources/streamfactories/StreamFactoryBase.scala
@@ -8,9 +8,9 @@ import org.apache.spark.streaming.dstream.DStream
 import scala.reflect.ClassTag
 
 abstract class StreamFactoryBase[A: ClassTag] extends StreamFactory[A]{
-  override def createStream(streamingContext: StreamingContext): PartialFunction[ConnectorConfig, DStream[A]] = {
+  override def createStream(ssc: StreamingContext): PartialFunction[ConnectorConfig, DStream[A]] = {
     case config if canHandle(config) =>
-      val stream = buildStream(streamingContext, config)
+      val stream = buildStream(ssc, config)
 
       stream.transform(rdd => {
         rdd.cache()
@@ -25,5 +25,5 @@ abstract class StreamFactoryBase[A: ClassTag] extends StreamFactory[A]{
   }
 
   protected def canHandle(connectorConfig: ConnectorConfig): Boolean
-  protected def buildStream(streamingContext: StreamingContext, connectorConfig: ConnectorConfig): DStream[A]
+  protected def buildStream(ssc: StreamingContext, connectorConfig: ConnectorConfig): DStream[A]
 }

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/sources/streamfactories/TwitterStreamFactory.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/sources/streamfactories/TwitterStreamFactory.scala
@@ -11,12 +11,11 @@ import twitter4j.conf.ConfigurationBuilder
 import twitter4j.{FilterQuery, Status}
 
 class TwitterStreamFactory extends StreamFactoryBase[Status] with Loggable {
-
   override protected def canHandle(connectorConfig: ConnectorConfig): Boolean = {
     connectorConfig.name == "Twitter"
   }
 
-  override protected def buildStream(streamingContext: StreamingContext, connectorConfig: ConnectorConfig): DStream[Status] = {
+  override protected def buildStream(ssc: StreamingContext, connectorConfig: ConnectorConfig): DStream[Status] = {
     import ParameterExtensions._
 
     val params = connectorConfig.parameters
@@ -41,7 +40,7 @@ class TwitterStreamFactory extends StreamFactoryBase[Status] with Loggable {
     }
 
     TwitterUtils.createFilteredStream(
-      streamingContext,
+      ssc,
       twitterAuth = Some(auth),
       query = Some(query))
   }


### PR DESCRIPTION
Add appinsights event logging to all streams through `StreamFactoryBase.scala`.

This does not add the timing utility for event logging. That will be done in a separate PR.