### PR TITLE
Fix issue with getting streams for pipeline

### DIFF
--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/dba/CassandraConfigurationManager.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/dba/CassandraConfigurationManager.scala
@@ -22,7 +22,7 @@ class CassandraConfigurationManager extends ConfigurationManager with Serializab
     }
 
     val pipelineConfigRows = sparkContext.cassandraTable[CassandraSchema.Table.Stream](CassandraSchema.KeyspaceName,
-      CassandraSchema.Table.StreamsName).collect()
+      CassandraSchema.Table.StreamsName).where("pipelinekey = ?", pipeline).collect()
 
     pipelineConfigRows.map(stream => {
       val trustedSources = connectorToTrustedSources.computeIfAbsent(stream.streamfactory, (fetchTrustedSources _).asJava)


### PR DESCRIPTION
Previously, all configs in `streams` table were being returned for all pipelines due to missing `where` clause.