### PR TITLE
Fix typos in column names

### DIFF
--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/sinks/cassandra/CassandraEventSchema.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/sinks/cassandra/CassandraEventSchema.scala
@@ -118,7 +118,7 @@ object CassandraEventTopicSchema {
       pipelinekey = item.pipelinekey,
       eventid = item.eventid,
       topic = kw.toLowerCase,
-      eventime = item.eventtime,
+      eventtime = item.eventtime,
       insertiontime = new Date().getTime,
       externalsourceid = item.externalsourceid
     )
@@ -135,7 +135,7 @@ object CassandraEventPlacesSchema {
       centroidlat = location.centroidlat,
       centroidlon = location.centroidlon,
       eventid = item.eventid,
-      eventime = item.eventtime,
+      eventtime = item.eventtime,
       conjunctiontopic1 = ct._1,
       conjunctiontopic2 = ct._2,
       conjunctiontopic3 = ct._3,

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/sinks/cassandra/dto/FortisRecords.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/sinks/cassandra/dto/FortisRecords.scala
@@ -25,7 +25,7 @@ case class EventTopics(
                         insertiontime: Long,
                         eventid: String,
                         externalsourceid: String,
-                        eventime: Long,
+                        eventtime: Long,
                         topic: String) extends Serializable
 
 case class EventPlaces(
@@ -38,7 +38,7 @@ case class EventPlaces(
                         conjunctiontopic2: String,
                         conjunctiontopic3: String,
                         externalsourceid: String,
-                        eventime: Long,
+                        eventtime: Long,
                         placeid: String) extends Serializable
 
 case class PopularPlaceAggregate(


### PR DESCRIPTION
This is the spark-side change for the following schema pull request:
https://github.com/CatalystCode/project-fortis-pipeline/pull/106