### PR TITLE
Add telemetry for sink phases and remove retry

### DIFF
--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/logging/AppInsightsTelemetry.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/logging/AppInsightsTelemetry.scala
@@ -26,7 +26,6 @@ class AppInsightsTelemetry extends FortisTelemetry {
     metrics.put("duration", duration.toDouble)
 
     val name = s"batch.sink.$eventName"
-
     client.trackEvent(name, properties, metrics)
   }
 

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/logging/AppInsightsTelemetry.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/logging/AppInsightsTelemetry.scala
@@ -18,14 +18,14 @@ class AppInsightsTelemetry extends FortisTelemetry {
     client.trackEvent("batch.receive", properties, metrics)
   }
 
-  def logSink(duration: Long, eventName: String, batchSize: Long): Unit = {
-    val name = s"batch.sink.$eventName"
-
+  def logSink(eventName: String, duration: Long, batchSize: Long): Unit = {
     val properties = new util.HashMap[String, String](0)
 
     val metrics = new util.HashMap[String, java.lang.Double](2)
     metrics.put("batchSize", batchSize.toDouble)
     metrics.put("duration", duration.toDouble)
+
+    val name = s"batch.sink.$eventName"
 
     client.trackEvent(name, properties, metrics)
   }

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/logging/AppInsightsTelemetry.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/logging/AppInsightsTelemetry.scala
@@ -18,8 +18,9 @@ class AppInsightsTelemetry extends FortisTelemetry {
     client.trackEvent("batch.receive", properties, metrics)
   }
 
-  def logSink(eventName: String, duration: Long, batchSize: Long): Unit = {
-    val properties = new util.HashMap[String, String](0)
+  def logSinkPhase(eventName: String, succeeded: Boolean, duration: Long, batchSize: Long): Unit = {
+    val properties = new util.HashMap[String, String](1)
+    properties.put("succeeded", succeeded.toString)
 
     val metrics = new util.HashMap[String, java.lang.Double](2)
     metrics.put("batchSize", batchSize.toDouble)

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/logging/AppInsightsTelemetry.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/logging/AppInsightsTelemetry.scala
@@ -19,7 +19,7 @@ class AppInsightsTelemetry extends FortisTelemetry {
   }
 
   def logSink(duration: Long, eventName: String, batchSize: Long): Unit = {
-    val name = "batch.sink." + eventName
+    val name = s"batch.sink.$eventName"
 
     val properties = new util.HashMap[String, String](0)
 

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/logging/AppInsightsTelemetry.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/logging/AppInsightsTelemetry.scala
@@ -18,14 +18,16 @@ class AppInsightsTelemetry extends FortisTelemetry {
     client.trackEvent("batch.receive", properties, metrics)
   }
 
-  def logCassandraEventsSink(duration: Long, batchSize: Long): Unit = {
+  def logSink(duration: Long, eventName: String, batchSize: Long): Unit = {
+    val name = "batch.sink." + eventName
+
     val properties = new util.HashMap[String, String](0)
 
     val metrics = new util.HashMap[String, java.lang.Double](2)
     metrics.put("batchSize", batchSize.toDouble)
     metrics.put("duration", duration.toDouble)
 
-    client.trackEvent("batch.sink", properties, metrics)
+    client.trackEvent(name, properties, metrics)
   }
 
   def logLanguageDetection(language: Option[String]): Unit = {

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/logging/FortisTelemetry.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/logging/FortisTelemetry.scala
@@ -2,7 +2,7 @@ package com.microsoft.partnercatalyst.fortis.spark.logging
 
 trait FortisTelemetry {
   def logIncomingEventBatch(streamId: String, connectorName: String, batchSize: Long): Unit
-  def logCassandraEventsSink(duration: Long, batchSize: Long): Unit
+  def logSink(duration: Long, eventName: String, batchSize: Long): Unit
   def logLanguageDetection(language: Option[String]): Unit
 }
 

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/logging/FortisTelemetry.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/logging/FortisTelemetry.scala
@@ -2,7 +2,7 @@ package com.microsoft.partnercatalyst.fortis.spark.logging
 
 trait FortisTelemetry {
   def logIncomingEventBatch(streamId: String, connectorName: String, batchSize: Long): Unit
-  def logSink(duration: Long, eventName: String, batchSize: Long): Unit
+  def logSink(eventName: String, duration: Long, batchSize: Long): Unit
   def logLanguageDetection(language: Option[String]): Unit
 }
 

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/logging/FortisTelemetry.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/logging/FortisTelemetry.scala
@@ -2,12 +2,12 @@ package com.microsoft.partnercatalyst.fortis.spark.logging
 
 trait FortisTelemetry {
   def logIncomingEventBatch(streamId: String, connectorName: String, batchSize: Long): Unit
-  def logSink(eventName: String, duration: Long, batchSize: Long): Unit
+  def logSinkPhase(eventName: String, succeeded: Boolean, duration: Long, batchSize: Long): Unit
   def logLanguageDetection(language: Option[String]): Unit
 }
 
 object FortisTelemetry {
   private lazy val telemetry: FortisTelemetry = new AppInsightsTelemetry()
 
-  def get(): FortisTelemetry = telemetry
+  def get: FortisTelemetry = telemetry
 }

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/logging/Timer.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/logging/Timer.scala
@@ -12,8 +12,8 @@ object Timer {
     callback(result.isSuccess, duration)
 
     result match {
-      case Success(r) => r
-      case Failure(t) => throw t
+      case Success(res) => res
+      case Failure(th) => throw th
     }
   }
 }

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/logging/Timer.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/logging/Timer.scala
@@ -1,12 +1,19 @@
 package com.microsoft.partnercatalyst.fortis.spark.logging
 
+import scala.util.{Failure, Success, Try}
+
 object Timer {
-  def time[R](callback: Long => Unit)(block: => R): R = {
+  def time[R](callback: (Boolean, Long) => Unit)(block: => R): R = {
     val startTime = System.nanoTime()
-    val result = block
+    val result = Try(block)
     val endTime = System.nanoTime()
+
     val duration = endTime - startTime
-    callback(duration)
-    result
+    callback(result.isSuccess, duration)
+
+    result match {
+      case Success(r) => r
+      case Failure(t) => throw t
+    }
   }
 }

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/sinks/cassandra/CassandraEventsSink.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/sinks/cassandra/CassandraEventsSink.scala
@@ -36,7 +36,7 @@ object CassandraEventsSink{
           val batchSize = eventsRDD.count()
           val batchid = UUID.randomUUID().toString
           val fortisEventsRDD = eventsRDD.map(CassandraEventSchema(_, batchid))
-          Timer.time(FortisTelemetry.get().logSink(_, "save", batchSize)) {
+          Timer.time(FortisTelemetry.get().logSink("save", _, batchSize)) {
             writeFortisEvents(fortisEventsRDD, batchid)
           }
           val aggregators = Seq(
@@ -51,12 +51,12 @@ object CassandraEventsSink{
 
           registerUDFs(session)
           val eventBatchDF = fetchEventBatch(batchid, fortisEventsRDD, session)
-          Timer.time(FortisTelemetry.get().logSink(_, "tagtables", batchSize)) {
+          Timer.time(FortisTelemetry.get().logSink("tagtables", _, batchSize)) {
             writeEventBatchToEventTagTables(eventBatchDF, session)
           }
           aggregators.foreach(aggregator => {
             val eventName = aggregator.FortisTargetTablename
-            Timer.time(FortisTelemetry.get().logSink(_, eventName, batchSize)) {
+            Timer.time(FortisTelemetry.get().logSink(eventName, _, batchSize)) {
               aggregateEventBatch(eventBatchDF, session, aggregator)
             }
           })

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/sinks/cassandra/CassandraEventsSink.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/sinks/cassandra/CassandraEventsSink.scala
@@ -26,7 +26,7 @@ object CassandraEventsSink{
     dstream.foreachRDD{ (eventsRDD, time: Time) => {
       eventsRDD.cache()
 
-      if(!eventsRDD.isEmpty) {
+      if (!eventsRDD.isEmpty) {
         val batchSize = eventsRDD.count()
         val batchid = UUID.randomUUID().toString
         val fortisEventsRDD = eventsRDD.map(CassandraEventSchema(_, batchid))

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/sinks/cassandra/CassandraEventsSink.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/sinks/cassandra/CassandraEventsSink.scala
@@ -28,48 +28,48 @@ object CassandraEventsSink{
   private val CassandraMaxRetryAttempts = 3
 
   def apply(dstream: DStream[FortisEvent], sparkSession: SparkSession): Unit = {
-      val batchStream = dstream.foreachRDD{ (eventsRDD, time: Time) => {
-        eventsRDD.cache()
+    val batchStream = dstream.foreachRDD{ (eventsRDD, time: Time) => {
+      eventsRDD.cache()
 
-        if(!eventsRDD.isEmpty) {
-          val batchSize = eventsRDD.count()
-          val batchid = UUID.randomUUID().toString
-          val fortisEventsRDD = eventsRDD.map(CassandraEventSchema(_, batchid))
+      if(!eventsRDD.isEmpty) {
+        val batchSize = eventsRDD.count()
+        val batchid = UUID.randomUUID().toString
+        val fortisEventsRDD = eventsRDD.map(CassandraEventSchema(_, batchid))
 
-          Timer.time(FortisTelemetry.get().logSink("save", _, batchSize)) {
-            writeFortisEvents(fortisEventsRDD, batchid)
-          }
-
-          val aggregators = Seq(
-            new ConjunctiveTopicsAggregator,
-            new PopularPlacesAggregator,
-            new PopularTopicAggregator,
-            new ComputedTilesAggregator
-          ).par
-
-          val session = SparkSession.builder().config(eventsRDD.sparkContext.getConf)
-            .appName(eventsRDD.sparkContext.appName)
-            .getOrCreate()
-
-          registerUDFs(session)
-
-          val eventBatchDF = Timer.time(FortisTelemetry.get().logSink("fetch", _, batchSize)) {
-            fetchEventBatch(batchid, fortisEventsRDD, session)
-          }
-
-          Timer.time(FortisTelemetry.get().logSink("tagtables", _, batchSize)) {
-            writeEventBatchToEventTagTables(eventBatchDF, session)
-          }
-
-          aggregators.foreach(aggregator => {
-            val eventName = aggregator.FortisTargetTablename
-
-            Timer.time(FortisTelemetry.get().logSink(eventName, _, batchSize)) {
-              aggregateEventBatch(eventBatchDF, session, aggregator)
-            }
-          })
+        Timer.time(FortisTelemetry.get().logSink("save", _, batchSize)) {
+          writeFortisEvents(fortisEventsRDD, batchid)
         }
-      }}
+
+        val aggregators = Seq(
+          new ConjunctiveTopicsAggregator,
+          new PopularPlacesAggregator,
+          new PopularTopicAggregator,
+          new ComputedTilesAggregator
+        ).par
+
+        val session = SparkSession.builder().config(eventsRDD.sparkContext.getConf)
+          .appName(eventsRDD.sparkContext.appName)
+          .getOrCreate()
+
+        registerUDFs(session)
+
+        val eventBatchDF = Timer.time(FortisTelemetry.get().logSink("fetch", _, batchSize)) {
+          fetchEventBatch(batchid, fortisEventsRDD, session)
+        }
+
+        Timer.time(FortisTelemetry.get().logSink("tagtables", _, batchSize)) {
+          writeEventBatchToEventTagTables(eventBatchDF, session)
+        }
+
+        aggregators.foreach(aggregator => {
+          val eventName = aggregator.FortisTargetTablename
+
+          Timer.time(FortisTelemetry.get().logSink(eventName, _, batchSize)) {
+            aggregateEventBatch(eventBatchDF, session, aggregator)
+          }
+        })
+      }
+    }}
   }
 
   private def writeFortisEvents(events: RDD[Event], batchId: String ): Unit = {

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/sinks/cassandra/CassandraEventsSink.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/sinks/cassandra/CassandraEventsSink.scala
@@ -55,7 +55,8 @@ object CassandraEventsSink{
             writeEventBatchToEventTagTables(eventBatchDF, session)
           }
           aggregators.foreach(aggregator => {
-            Timer.time(FortisTelemetry.get().logSink(_, "aggregate", batchSize)) {
+            val eventName = aggregator.FortisTargetTablename
+            Timer.time(FortisTelemetry.get().logSink(_, eventName, batchSize)) {
               aggregateEventBatch(eventBatchDF, session, aggregator)
             }
           })

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/sources/streamfactories/StreamFactoryBase.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/sources/streamfactories/StreamFactoryBase.scala
@@ -17,7 +17,7 @@ abstract class StreamFactoryBase[A: ClassTag] extends StreamFactory[A]{
         val batchSize = rdd.count()
         val streamId = config.parameters("streamId").toString
         val connectorName = config.name
-        val telemetry = FortisTelemetry.get()
+        val telemetry = FortisTelemetry.get
         telemetry.logIncomingEventBatch(streamId, connectorName, batchSize)
 
         rdd

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/transforms/language/LocalLanguageDetector.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/transforms/language/LocalLanguageDetector.scala
@@ -20,7 +20,7 @@ class LocalLanguageDetector extends LanguageDetector {
 
     val language = detectWithFactory(text, if (text.length <= 200) shortTextFactory else largeTextFactory)
 
-    FortisTelemetry.get().logLanguageDetection(language)
+    FortisTelemetry.get.logLanguageDetection(language)
     language
   }
 


### PR DESCRIPTION
Builds on the work @Smarker did for telemetry for individual Cassandra sink phases.

- Adds error handling for phase telemetry (non-fatal exceptions won't prevent telemetry from being collected).
- Removes redundant retry loops (this is handled in the Cassandra connector with a default of 10 retries).