### PR TITLE
Remove parallelization of aggregators for UI visibility

### DIFF
--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/sinks/cassandra/CassandraEventsSink.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/sinks/cassandra/CassandraEventsSink.scala
@@ -40,7 +40,7 @@ object CassandraEventsSink{
           new PopularPlacesAggregator,
           new PopularTopicAggregator,
           new ComputedTilesAggregator
-        ).par
+        )
 
         val session = SparkSession.builder().config(eventsRDD.sparkContext.getConf)
           .appName(eventsRDD.sparkContext.appName)


### PR DESCRIPTION
Removing this unveils previously hidden jobs for our batches, giving us more visibility for performance debugging.