### PR TITLE
Move Cassandra sink helper methods in scope of connection implicit

### DIFF
--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/sinks/cassandra/CassandraEventsSink.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/sinks/cassandra/CassandraEventsSink.scala
@@ -27,6 +27,8 @@ object CassandraEventsSink{
   def apply(dstream: DStream[FortisEvent], sparkSession: SparkSession): Unit = {
     implicit lazy val connector: CassandraConnector = CassandraConnector(sparkSession.sparkContext)
 
+    registerUDFs(sparkSession)
+
     dstream.foreachRDD{ (eventsRDD, time: Time) => {
       eventsRDD.cache()
 
@@ -34,6 +36,8 @@ object CassandraEventsSink{
         val batchSize = eventsRDD.count()
         val batchid = UUID.randomUUID().toString
         val fortisEventsRDD = eventsRDD.map(CassandraEventSchema(_, batchid))
+
+        fortisEventsRDD.cache()
 
         Timer.time(Telemetry.logSinkPhase("writeEvents", _, _, batchSize)) {
           writeFortisEvents(fortisEventsRDD)
@@ -46,75 +50,69 @@ object CassandraEventsSink{
           new ComputedTilesAggregator
         )
 
-        val session = SparkSession.builder().config(eventsRDD.sparkContext.getConf)
-          .appName(eventsRDD.sparkContext.appName)
-          .getOrCreate()
-
-        registerUDFs(session)
-
         val eventBatchDF = Timer.time(Telemetry.logSinkPhase("fetchEventsByBatchId", _, _, batchSize)) {
-          fetchEventBatch(batchid, fortisEventsRDD, session)
+          fetchEventBatch(batchid, fortisEventsRDD, sparkSession)
         }
 
         Timer.time(Telemetry.logSinkPhase("writeTagTables", _, _, batchSize)) {
-          writeEventBatchToEventTagTables(eventBatchDF, session)
+          writeEventBatchToEventTagTables(eventBatchDF, sparkSession)
         }
 
         aggregators.foreach(aggregator => {
           val eventName = aggregator.FortisTargetTablename
 
           Timer.time(Telemetry.logSinkPhase(s"aggregate_$eventName", _, _, batchSize)) {
-            aggregateEventBatch(eventBatchDF, session, aggregator)
+            aggregateEventBatch(eventBatchDF, sparkSession, aggregator)
           }
         })
       }
     }}
-  }
 
-  private def writeFortisEvents(events: RDD[Event]): Unit = {
-    events.saveToCassandra(KeyspaceName, TableEvent, writeConf = WriteConf(ifNotExists = true))
-  }
+    def writeFortisEvents(events: RDD[Event]): Unit = {
+      events.saveToCassandra(KeyspaceName, TableEvent, writeConf = WriteConf(ifNotExists = true))
+    }
 
-  private def registerUDFs(session: SparkSession): Unit ={
-    session.udf.register("MeanAverage", FortisUdfFunctions.MeanAverage)
-    session.udf.register("SumMentions", FortisUdfFunctions.OptionalSummation)
-    session.udf.register("MergeHeatMap", FortisUdfFunctions.MergeHeatMap)
-    session.udf.register("SentimentWeightedAvg", SentimentWeightedAvg)
-  }
+    def registerUDFs(session: SparkSession): Unit ={
+      session.udf.register("MeanAverage", FortisUdfFunctions.MeanAverage)
+      session.udf.register("SumMentions", FortisUdfFunctions.OptionalSummation)
+      session.udf.register("MergeHeatMap", FortisUdfFunctions.MergeHeatMap)
+      session.udf.register("SentimentWeightedAvg", SentimentWeightedAvg)
+    }
 
-  private def fetchEventBatch(batchid: String, events: RDD[Event], session: SparkSession): Dataset[Event] = {
-    import session.implicits._
+    def fetchEventBatch(batchid: String, events: RDD[Event], session: SparkSession): Dataset[Event] = {
+      import session.implicits._
 
-    val addedEventsDF = session.read.format(CassandraFormat)
-      .options(Map("keyspace" -> KeyspaceName, "table" -> TableEventBatches))
-      .load()
+      val addedEventsDF = session.read.format(CassandraFormat)
+        .options(Map("keyspace" -> KeyspaceName, "table" -> TableEventBatches))
+        .load()
 
-    addedEventsDF.createOrReplaceTempView(TableEventBatches)
-    val ds = session.sql(s"select eventid, pipelinekey from $TableEventBatches where batchid = '$batchid'")
-    val eventsDS = events.toDF().as[Event]
-    val filteredEvents = eventsDS.join(ds, Seq("eventid", "pipelinekey")).as[Event]
+      addedEventsDF.createOrReplaceTempView(TableEventBatches)
+      val ds = session.sql(s"select eventid, pipelinekey from $TableEventBatches where batchid = '$batchid'")
+      val eventsDS = events.toDF().as[Event]
+      val filteredEvents = eventsDS.join(ds, Seq("eventid", "pipelinekey")).as[Event]
 
-    filteredEvents.cache()
-    filteredEvents
-  }
+      filteredEvents.cache()
+      filteredEvents
+    }
 
-  private def writeEventBatchToEventTagTables(eventDS: Dataset[Event], session: SparkSession): Unit = {
-    import session.implicits._
-    eventDS.flatMap(CassandraEventTopicSchema(_)).rdd.saveToCassandra(KeyspaceName, TableEventTopics)
-    eventDS.flatMap(CassandraEventPlacesSchema(_)).rdd.saveToCassandra(KeyspaceName, TableEventPlaces)
-  }
+    def writeEventBatchToEventTagTables(eventDS: Dataset[Event], session: SparkSession): Unit = {
+      import session.implicits._
+      eventDS.flatMap(CassandraEventTopicSchema(_)).rdd.saveToCassandra(KeyspaceName, TableEventTopics)
+      eventDS.flatMap(CassandraEventPlacesSchema(_)).rdd.saveToCassandra(KeyspaceName, TableEventPlaces)
+    }
 
-  private def aggregateEventBatch(eventDS: Dataset[Event], session: SparkSession, aggregator: FortisAggregator): Unit = {
-    val flattenedDF = aggregator.flattenEvents(session, eventDS)
-    flattenedDF.createOrReplaceTempView(aggregator.DfTableNameFlattenedEvents)
+    def aggregateEventBatch(eventDS: Dataset[Event], session: SparkSession, aggregator: FortisAggregator): Unit = {
+      val flattenedDF = aggregator.flattenEvents(session, eventDS)
+      flattenedDF.createOrReplaceTempView(aggregator.DfTableNameFlattenedEvents)
 
-    val aggregatedDF = aggregator.AggregateEventBatches(session, flattenedDF)
-    aggregatedDF.createOrReplaceTempView(aggregator.DfTableNameComputedAggregates)
+      val aggregatedDF = aggregator.AggregateEventBatches(session, flattenedDF)
+      aggregatedDF.createOrReplaceTempView(aggregator.DfTableNameComputedAggregates)
 
-    val incrementallyUpdatedDF = aggregator.IncrementalUpdate(session, aggregatedDF)
-    incrementallyUpdatedDF.write
-      .format(CassandraFormat)
-      .mode(SaveMode.Append)
-      .options(Map("keyspace" -> KeyspaceName, "table" -> aggregator.FortisTargetTablename)).save
+      val incrementallyUpdatedDF = aggregator.IncrementalUpdate(session, aggregatedDF)
+      incrementallyUpdatedDF.write
+        .format(CassandraFormat)
+        .mode(SaveMode.Append)
+        .options(Map("keyspace" -> KeyspaceName, "table" -> aggregator.FortisTargetTablename)).save
+    }
   }
 }


### PR DESCRIPTION
- Moves helper methods in scope of the Cassandra connection implicit.
- Moves registration of UDFs outside of the foreach RDD loop.
- Adds caching for schema-fied fortis events.