### PR TITLE
Use saveToCassandra instead of implicit write

### DIFF
--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/sinks/cassandra/CassandraEventsSink.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/sinks/cassandra/CassandraEventsSink.scala
@@ -4,7 +4,7 @@ import java.util.UUID
 
 import com.datastax.spark.connector.writer.WriteConf
 import com.microsoft.partnercatalyst.fortis.spark.dto.FortisEvent
-import org.apache.spark.sql.{Dataset, SaveMode, SparkSession}
+import org.apache.spark.sql.{Dataset, SparkSession}
 import org.apache.spark.streaming.dstream.DStream
 import com.datastax.spark.connector._
 import com.datastax.spark.connector.cql.CassandraConnector
@@ -139,11 +139,8 @@ object CassandraEventsSink{
         incrementallyUpdatedDF
       }
 
-      Timer.time(Telemetry.logSinkPhase(s"incrementallyUpdatedDF.write-${aggregator.FortisTargetTablename}", _, _, -1)) {
-        incrementallyUpdatedDF.write
-          .format(CassandraFormat)
-          .mode(SaveMode.Append)
-          .options(Map("keyspace" -> KeyspaceName, "table" -> aggregator.FortisTargetTablename)).save
+      Timer.time(Telemetry.logSinkPhase(s"incrementallyUpdatedDF.saveToCassandra-${aggregator.FortisTargetTablename}", _, _, -1)) {
+        incrementallyUpdatedDF.rdd.saveToCassandra(KeyspaceName, aggregator.FortisTargetTablename)
       }
     }
   }


### PR DESCRIPTION
There is a 3x performance difference between our writes that go via `saveToCassandra` and via `DF.write`. Maybe because `saveToCassandra` uses our implicit Cassandra connection but the `DF.write` doesn't?

In either case, this change is still valuable since it increases consistency of the Cassandra sink so that we don't have two ways of writing data to Cassandra and just always use `saveToCassandra`.

Sample perf data:

```csv
batch.sink.incrementallyUpdatedDF.write-popularplaces,3.0803832716
batch.sink.incrementallyUpdatedDF.write-populartopics,3.0055997492
batch.sink.incrementallyUpdatedDF.write-conjunctivetopics,3.5709079721
batch.sink.saveToCassandra-eventtopics,0.9835134393
batch.sink.saveToCassandra-eventplaces,0.6667939515
```