### PR TITLE
Use same load balancing policy as fortis-services

### DIFF
--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/sinks/cassandra/CassandraConfig.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/sinks/cassandra/CassandraConfig.scala
@@ -15,5 +15,6 @@ object CassandraConfig {
       .setIfMissing("spark.cassandra.auth.username", CassandraUsername)
       .setIfMissing("spark.cassandra.auth.password", CassandraPassword)
       .setIfMissing("spark.cassandra.connection.keep_alive_ms", envOrElse("CASSANDRA_KEEP_ALIVE_MS", (batchDuration.milliseconds * 2).toString))
+      .setIfMissing("spark.cassandra.connection.factory", "com.microsoft.partnercatalyst.fortis.spark.sinks.cassandra.FortisConnectionFactory")
   }
 }

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/sinks/cassandra/FortisConnectionFactory.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/sinks/cassandra/FortisConnectionFactory.scala
@@ -1,0 +1,14 @@
+package com.microsoft.partnercatalyst.fortis.spark.sinks.cassandra
+
+import com.datastax.driver.core.Cluster
+import com.datastax.driver.core.policies.{DCAwareRoundRobinPolicy, TokenAwarePolicy}
+import com.datastax.spark.connector.cql.{CassandraConnectionFactory, CassandraConnectorConf, DefaultConnectionFactory}
+
+object FortisConnectionFactory extends CassandraConnectionFactory {
+  override def createCluster(conf: CassandraConnectorConf): Cluster = {
+    DefaultConnectionFactory
+      .clusterBuilder(conf)
+      .withLoadBalancingPolicy(new TokenAwarePolicy(new DCAwareRoundRobinPolicy.Builder().build()))
+      .build()
+  }
+}


### PR DESCRIPTION
For some reason we're seeing ~80ms write times from fortis-services to Cassandra but multi-second write times from fortis-spark to Cassandra.

One of the differences between the two setups is that fortis-services uses the NodeJS connector which has a different default load-balancing policy than the Spark connector used in fortis-spark which assumes that Spark workers and Cassandra nodes are co-located on the same hosts (which is not the case in our deployment). This change makes the setup consistent so that both projects use the same load-balancing policy.