### PR TITLE
Remove bad exception for unset shared locations

### DIFF
--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/analyzer/FacebookPostAnalyzer.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/analyzer/FacebookPostAnalyzer.scala
@@ -20,10 +20,7 @@ class FacebookPostAnalyzer extends Analyzer[FacebookPost] with Serializable with
       pipelinekey = "Facebook",
       sharedLocations = Option(item.post.getPlace).map(_.getLocation) match {
         case Some(location) => locationFetcher(location.getLatitude, location.getLongitude).toList
-        case None =>
-          val errorMsg = "Empty PageIds argument for Facebook connector stream"
-          logFatalError(errorMsg)
-          throw new IllegalArgumentException(errorMsg)
+        case None => List()
       },
       sourceurl = item.post.getPermalinkUrl.toString,
       original = item


### PR DESCRIPTION
This looks like the results of a bad merge; what reason would we have to throw an exception regarding pageIds when checking the shared locations in a Facebook post? Seems more sensible to simply treat posts without a tagged location as not having shared locations.