### PR TITLE
Ensure that place centroids are set in Cassandra

### DIFF
--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/CassandraTest.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/CassandraTest.scala
@@ -1,16 +1,15 @@
 package com.microsoft.partnercatalyst.fortis.spark
 
-import java.util.{Date, Locale, UUID}
+import java.util.{Date, UUID}
 
 import com.microsoft.partnercatalyst.fortis.spark.dto._
-import org.apache.spark.streaming.{Seconds, StreamingContext}
-import org.apache.spark.{SparkConf, SparkContext}
-
-import scala.collection.mutable
 import com.microsoft.partnercatalyst.fortis.spark.sinks.cassandra._
+import org.apache.spark.SparkConf
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.streaming.dstream.DStream
+import org.apache.spark.streaming.{Seconds, StreamingContext}
 
+import scala.collection.mutable
 import scala.util.Properties.{envOrElse, envOrNone}
 
 object CassandraTest {
@@ -66,7 +65,7 @@ object CassandraTest {
         title = "twitter post" ),
       analysis = Analysis(
         sentiments = List(.5),
-        locations = List(Location(wofId = "wof-85670485", confidence = Option(1.0), latitude = Option(12.21), longitude = Option(43.1)), Location(wofId = "wof-85680959", confidence = Option(1.0), latitude = Option(14.21), longitude = Option(43.1))),
+        locations = List(Location(wofId = "wof-85670485", confidence = Option(1.0), latitude = 12.21, longitude = 43.1), Location(wofId = "wof-85680959", confidence = Option(1.0), latitude = 14.21, longitude = 43.1)),
         keywords = List(Tag(name = "isis", confidence = Option(1.0)), Tag(name ="car", confidence = Option(1.0))),
        //todo genders = List(Tag(name = "male", confidence = Option(1.0)), Tag(name ="female", confidence = Option(1.0))),
         entities = List(Tag(name = "putin", confidence = Option(1.0))),
@@ -85,7 +84,7 @@ object CassandraTest {
           title = "twitter post" ),
         analysis = Analysis(
           sentiments = List(.6),
-          locations = List(Location(wofId = "wof-85670485", confidence = Option(1.0), latitude = Option(12.21), longitude = Option(43.1))),
+          locations = List(Location(wofId = "wof-85670485", confidence = Option(1.0), latitude = 12.21, longitude = 43.1)),
           keywords = List(Tag(name = "isis", confidence = Option(1.0)),
             Tag(name ="car", confidence = Option(1.0)),
             Tag(name ="bomb", confidence = Option(1.0)),
@@ -107,7 +106,7 @@ object CassandraTest {
           title = "twitter post" ),
         analysis = Analysis(
           sentiments = List(.6),
-          locations = List(Location(wofId = "wof-85670485", confidence = Option(1.0), latitude = Option(12.21), longitude = Option(43.1))),
+          locations = List(Location(wofId = "wof-85670485", confidence = Option(1.0), latitude = 12.21, longitude = 43.1)),
           keywords = List(Tag(name = "isis", confidence = Option(1.0)), Tag(name ="fear", confidence = Option(1.0)), Tag(name ="bomb", confidence = Option(1.0)), Tag(name ="fatalities", confidence = Option(1.0))),
           //todo genders = List(Tag(name = "male", confidence = Option(1.0)), Tag(name ="female", confidence = Option(1.0))),
           entities = List(Tag(name = "putin", confidence = Option(1.0))),

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/dto/FortisEvent.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/dto/FortisEvent.scala
@@ -1,5 +1,7 @@
 package com.microsoft.partnercatalyst.fortis.spark.dto
 
+import java.util.Objects
+
 trait FortisEvent {
   val details: Details
   val analysis: Analysis
@@ -30,10 +32,20 @@ case class Analysis(
 
 case class Location(
   wofId: String,
-  confidence: Option[Double] = None,
-  latitude: Option[Double] = None,
-  longitude: Option[Double] = None
-)
+  latitude: Double,
+  longitude: Double,
+  confidence: Option[Double] = None
+) {
+
+  override def equals(obj: scala.Any): Boolean = {
+    if (obj == null) return false
+    if (!obj.isInstanceOf[Location]) return false
+    val location = obj.asInstanceOf[Location]
+    Objects.equals(wofId, location.wofId)
+  }
+
+  override def hashCode(): Int = wofId.hashCode
+}
 
 case class Tag(
   name: String,

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/sinks/cassandra/CassandraEventSchema.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/sinks/cassandra/CassandraEventSchema.scala
@@ -212,10 +212,9 @@ object Utils {
   def getFeatures(item: FortisEvent): Features = {
     //todo val genderCounts = item.analysis.genders.map(_.name).groupBy(identity).mapValues(t=>t.size.toLong)
     val entityCounts = item.analysis.entities.map(_.name).groupBy(identity).mapValues(t=>t.size.toLong)
-    val zero = 0.toLong
     Features(
       mentions = 1,
-      places = item.analysis.locations.map(place => Place(placeid = place.wofId, centroidlat = place.latitude.getOrElse(-1), centroidlon = place.longitude.getOrElse(-1))),
+      places = item.analysis.locations.map(place => Place(placeid = place.wofId, centroidlat = place.latitude, centroidlon = place.longitude)),
       keywords = item.analysis.keywords.map(_.name),
       sentiment = Sentiment(neg_avg = getSentimentScore(item.analysis.sentiments)),
       entities = entityCounts.map(kv => Entities(

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/transforms/image/ImageAnalyzer.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/transforms/image/ImageAnalyzer.scala
@@ -2,6 +2,7 @@ package com.microsoft.partnercatalyst.fortis.spark.transforms.image
 
 import com.microsoft.partnercatalyst.fortis.spark.dto.{Analysis, Location, Tag}
 import com.microsoft.partnercatalyst.fortis.spark.transforms.locations.client.FeatureServiceClient
+import com.microsoft.partnercatalyst.fortis.spark.transforms.locations.dto.FeatureServiceFeature.toLocation
 import net.liftweb.json
 
 import scalaj.http.Http
@@ -49,6 +50,6 @@ class ImageAnalyzer(auth: ImageAnalysisAuth, featureServiceClient: FeatureServic
   protected def landmarksToLocations(marks: Iterable[dto.JsonImageLandmark]): Iterable[Location] = {
     val landmarks = marks.map(landmark => landmark.name -> landmark.confidence).toMap
     val features = featureServiceClient.name(landmarks.keys)
-    features.map(loc => Location(wofId = loc.id, confidence = landmarks.get(loc.name)))
+    features.map(loc => toLocation(loc).copy(confidence = landmarks.get(loc.name)))
   }
 }

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/transforms/locations/LocationsExtractor.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/transforms/locations/LocationsExtractor.scala
@@ -6,7 +6,7 @@ import com.microsoft.partnercatalyst.fortis.spark.transforms.locations.client.Fe
 
 @SerialVersionUID(100L)
 class LocationsExtractor private[locations](
-  lookup: Map[String, Set[String]],
+  lookup: Map[String, Set[Location]],
   featureServiceClient: FeatureServiceClient,
   placeRecognizer: Option[PlaceRecognizer] = None,
   ngrams: Int = 3
@@ -19,7 +19,7 @@ class LocationsExtractor private[locations](
 
     val candidatePlaces = extractCandidatePlaces(text).toSet
     val locationsInGeofence = candidatePlaces.flatMap(place => lookup.get(place.toLowerCase)).flatten
-    locationsInGeofence.map(wofId => Location(wofId, confidence = Some(0.5)))
+    locationsInGeofence.map(_.copy(confidence = Some(0.5)))
   }
 
   private def extractCandidatePlaces(text: String): Iterable[String] = {

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/transforms/locations/LocationsExtractorFactory.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/transforms/locations/LocationsExtractorFactory.scala
@@ -3,6 +3,7 @@ package com.microsoft.partnercatalyst.fortis.spark.transforms.locations
 import com.microsoft.partnercatalyst.fortis.spark.dto.{Geofence, Location}
 import com.microsoft.partnercatalyst.fortis.spark.logging.Loggable
 import com.microsoft.partnercatalyst.fortis.spark.transforms.locations.client.FeatureServiceClient
+import com.microsoft.partnercatalyst.fortis.spark.transforms.locations.dto.FeatureServiceFeature.toLocation
 
 import scala.collection.mutable
 
@@ -11,13 +12,13 @@ class LocationsExtractorFactory(
   featureServiceClient: FeatureServiceClient,
   geofence: Geofence) extends Serializable with Loggable {
 
-  protected var lookup: Map[String, Set[String]] = _
+  protected var lookup: Map[String, Set[Location]] = _
 
   def buildLookup(): this.type = {
-    val map = mutable.Map[String, mutable.Set[String]]()
+    val map = mutable.Map[String, mutable.Set[Location]]()
     featureServiceClient.bbox(geofence).foreach(location => {
       val key = location.name.toLowerCase
-      val value = location.id
+      val value = toLocation(location)
       map.getOrElseUpdate(key, mutable.Set()).add(value)
     })
 
@@ -33,6 +34,6 @@ class LocationsExtractorFactory(
   def fetch(latitude: Double, longitude: Double): Iterable[Location] = {
     val locationsForPoint = featureServiceClient.point(latitude = latitude, longitude = longitude)
     val locationsInGeofence = locationsForPoint.flatMap(location => lookup.get(location.name.toLowerCase)).flatten.toSet
-    locationsInGeofence.map(wofId => Location(wofId, confidence = Some(1.0), latitude = Some(latitude), longitude = Some(longitude)))
+    locationsInGeofence.map(_.copy(confidence = Some(1.0)))
   }
 }

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/transforms/locations/client/FeatureServiceClient.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/transforms/locations/client/FeatureServiceClient.scala
@@ -40,17 +40,17 @@ class FeatureServiceClient(apiUrlBase: String) extends Serializable with Loggabl
   }
 
   protected def fetchBboxResponse(geofence: Geofence): Try[String] = {
-    val fetch = s"$apiUrlBase/features/bbox/${geofence.north}/${geofence.west}/${geofence.south}/${geofence.east}"
+    val fetch = s"$apiUrlBase/features/bbox/${geofence.north}/${geofence.west}/${geofence.south}/${geofence.east}?include=centroid"
     fetchResponse(fetch)
   }
 
   protected def fetchPointResponse(latitude: Double, longitude: Double): Try[String] = {
-    val fetch = s"$apiUrlBase/features/point/$latitude/$longitude"
+    val fetch = s"$apiUrlBase/features/point/$latitude/$longitude?include=centroid"
     fetchResponse(fetch)
   }
 
   protected def fetchNameResponse(names: Iterable[String]): Try[String] = {
-    val fetch = s"$apiUrlBase/features/name/${names.mkString(",")}"
+    val fetch = s"$apiUrlBase/features/name/${names.mkString(",")}?include=centroid"
     fetchResponse(fetch)
   }
 

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/transforms/locations/dto/Json.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/transforms/locations/dto/Json.scala
@@ -1,4 +1,18 @@
 package com.microsoft.partnercatalyst.fortis.spark.transforms.locations.dto
 
+import com.microsoft.partnercatalyst.fortis.spark.dto.Location
+
 case class FeatureServiceResponse(features: List[FeatureServiceFeature])
-case class FeatureServiceFeature(id: String, name: String, layer: String)
+case class FeatureServiceFeature(id: String, name: String, layer: String, centroid: Option[List[Double]] = None)
+
+object FeatureServiceFeature {
+  val DefaultLatitude = -1d
+  val DefaultLongitude = -1d
+
+  def toLocation(feature: FeatureServiceFeature): Location = {
+    Location(
+      wofId = feature.id,
+      longitude = feature.centroid.map(_.head).getOrElse(DefaultLongitude),
+      latitude = feature.centroid.map(_.tail.head).getOrElse(DefaultLatitude))
+  }
+}

--- a/src/test/scala/com/microsoft/partnercatalyst/fortis/spark/transforms/image/ImageAnalyzerSpec.scala
+++ b/src/test/scala/com/microsoft/partnercatalyst/fortis/spark/transforms/image/ImageAnalyzerSpec.scala
@@ -7,7 +7,7 @@ import org.scalatest.FlatSpec
 class TestImageAnalyzer(cognitiveServicesResponse: String) extends ImageAnalyzer(ImageAnalysisAuth("key"), null) {
   override protected def callCognitiveServices(requestBody: String): String = cognitiveServicesResponse
   override def buildRequestBody(imageUrl: String): String = super.buildRequestBody(imageUrl)
-  override def landmarksToLocations(landmarks: Iterable[JsonImageLandmark]): Iterable[Location] = landmarks.map(x => Location(x.name, Some(x.confidence)))
+  override def landmarksToLocations(landmarks: Iterable[JsonImageLandmark]): Iterable[Location] = landmarks.map(x => Location(x.name, latitude = -1, longitude = -1, confidence = Some(x.confidence)))
 }
 
 class ImageAnalyzerSpec extends FlatSpec {
@@ -123,7 +123,7 @@ class ImageAnalyzerSpec extends FlatSpec {
       keywords = List(Tag("person", Some(0.98979085683822632)), Tag("man", Some(0.94493889808654785)), Tag("outdoor", Some(0.938492476940155)), Tag("window", Some(0.89513939619064331))),
       summary = Some("Satya Nadella sitting on a bench"),
       entities = List(Tag("Satya Nadella", Some(0.999028444))),
-      locations = List(Location(wofId = "Forbidden City", confidence = Some(0.9978346)))
+      locations = List(Location(wofId = "Forbidden City", latitude = -1, longitude = -1, confidence = Some(0.9978346)))
     ))
   }
 

--- a/src/test/scala/com/microsoft/partnercatalyst/fortis/spark/transforms/locations/LocationsExtractorSpec.scala
+++ b/src/test/scala/com/microsoft/partnercatalyst/fortis/spark/transforms/locations/LocationsExtractorSpec.scala
@@ -1,6 +1,6 @@
 package com.microsoft.partnercatalyst.fortis.spark.transforms.locations
 
-import com.microsoft.partnercatalyst.fortis.spark.dto.Geofence
+import com.microsoft.partnercatalyst.fortis.spark.dto.{Geofence, Location}
 import com.microsoft.partnercatalyst.fortis.spark.transforms.locations.client.FeatureServiceClient
 import com.microsoft.partnercatalyst.fortis.spark.transforms.locations.dto.FeatureServiceFeature
 import org.scalatest.FlatSpec
@@ -8,18 +8,22 @@ import org.scalatest.FlatSpec
 object LocationsExtractorSpec {
   val idNyc = "wof-1234"
   val idManhattan = "wof-5678"
+  val latNyc = 123
+  val lngNyc = 456
+  val latManhattan = 78
+  val lngManhattan = 90
 
   val testLookup = Map(
-    "nyc" -> Set(idNyc),
-    "ny" -> Set(idNyc),
-    "new york" -> Set(idNyc),
-    "big apple" -> Set(idManhattan),
-    "manhattan" -> Set(idManhattan)
+    "nyc" -> Set(Location(idNyc, latitude = latNyc, longitude = lngNyc)),
+    "ny" -> Set(Location(idNyc, latitude = latNyc, longitude = lngNyc)),
+    "new york" -> Set(Location(idNyc, latitude = latNyc, longitude = lngNyc)),
+    "big apple" -> Set(Location(idManhattan, latitude = latManhattan, longitude = lngManhattan)),
+    "manhattan" -> Set(Location(idManhattan, latitude = latManhattan, longitude = lngManhattan))
   )
 }
 
 class TestLocationsExtractorFactory(client: FeatureServiceClient) extends LocationsExtractorFactory(client, geofence = null) {
-  def getLookup: Map[String, Set[String]] = lookup
+  def getLookup: Map[String, Set[Location]] = lookup
 }
 
 class TestFeatureServiceClient(givenBbox: Seq[FeatureServiceFeature], givenPoint: Seq[FeatureServiceFeature]) extends FeatureServiceClient("http://some/test/url") {
@@ -52,10 +56,9 @@ class LocationsExtractorSpec extends FlatSpec {
     val extractorFactory = new TestLocationsExtractorFactory(client).buildLookup()
     val lookup = extractorFactory.getLookup
 
-    assert(lookup == Map(
-      "new york" -> Set("id1", "id2"),
-      "gowanus heights" -> Set("id3")
-    ))
+    assert(lookup.size == 2)
+    assert(lookup("new york").map(_.wofId) == Set("id1", "id2"))
+    assert(lookup("gowanus heights").map(_.wofId) == Set("id3"))
   }
 
   it should "handle point queries" in {

--- a/src/test/scala/com/microsoft/partnercatalyst/fortis/spark/transforms/locations/client/FeatureServiceClientSpec.scala
+++ b/src/test/scala/com/microsoft/partnercatalyst/fortis/spark/transforms/locations/client/FeatureServiceClientSpec.scala
@@ -1,7 +1,8 @@
 package com.microsoft.partnercatalyst.fortis.spark.transforms.locations.client
 
-import com.microsoft.partnercatalyst.fortis.spark.dto.Geofence
+import com.microsoft.partnercatalyst.fortis.spark.dto.{Geofence, Location}
 import com.microsoft.partnercatalyst.fortis.spark.transforms.locations.dto.FeatureServiceFeature
+import com.microsoft.partnercatalyst.fortis.spark.transforms.locations.dto.FeatureServiceFeature.{DefaultLatitude, DefaultLongitude, toLocation}
 import org.scalatest.FlatSpec
 
 import scala.util.Try
@@ -16,13 +17,13 @@ class FeatureServiceClientSpec extends FlatSpec {
       """
         |{"features":[
         |  {"id":"wof-1108832169","name":"Ansonia","layer":"microhood"},
-        |  {"id":"wof-102061079","name":"Gowanus Heights","layer":"neighbourhood"}
+        |  {"id":"wof-102061079","name":"Gowanus Heights","layer":"neighbourhood","centroid":[-1.2,3.4]}
         |]}
       """.stripMargin).bbox(null)
 
     assert(response === Seq(
-      FeatureServiceFeature(id = "wof-1108832169", name = "Ansonia", layer = "microhood"),
-      FeatureServiceFeature(id = "wof-102061079", name = "Gowanus Heights", layer = "neighbourhood")
+      FeatureServiceFeature(id = "wof-1108832169", name = "Ansonia", layer = "microhood", centroid = None),
+      FeatureServiceFeature(id = "wof-102061079", name = "Gowanus Heights", layer = "neighbourhood", centroid = Some(List(-1.2, 3.4)))
     ))
   }
 
@@ -30,5 +31,17 @@ class FeatureServiceClientSpec extends FlatSpec {
     val response = new TestFeatureServiceClient("""<html>Certainly not json</html>""").bbox(null)
 
     assert(response.toList.isEmpty)
+  }
+
+  it should "convert features to locations" in {
+    val feature = FeatureServiceFeature(id = "wof-102061079", name = "Gowanus Heights", layer = "neighbourhood", centroid = None)
+    val location = Location(wofId = "wof-102061079", confidence = None, longitude = DefaultLongitude, latitude = DefaultLatitude)
+    assert(location == toLocation(feature))
+  }
+
+  it should "convert features to locations with centroids" in {
+    val feature = FeatureServiceFeature(id = "wof-102061079", name = "Gowanus Heights", layer = "neighbourhood", centroid = Some(List(-1.2, 3.4)))
+    val location = Location(wofId = "wof-102061079", confidence = None, longitude = -1.2, latitude = 3.4)
+    assert(location == toLocation(feature))
   }
 }


### PR DESCRIPTION
This requires two pieces:

1) A feature recently was added to the featureService that enables the return of the centroid of a place using `ST_Centroid` in PostGIS. You can find a sample featureService request that includes place centroids in the response at https://aka.ms/b5ldsw.  This feature is now integrated in the Spark pipeline so that we augment all detected locations with their WOF ids and their centroids.

2) The Cassandra aggregation logic and downstream GraphQL services assume that the centroid of places are always set. As such, we shouldn't represent the place coordinates in Spark as Optionals.