### PR TITLE
Only keep most granular location for a given name

### DIFF
--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/CassandraTest.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/CassandraTest.scala
@@ -66,7 +66,7 @@ object CassandraTest {
         title = "twitter post" ),
       analysis = Analysis(
         sentiments = List(.5),
-        locations = List(Location(wofId = "wof-85670485", confidence = Option(1.0), latitude = 12.21, longitude = 43.1), Location(wofId = "wof-85680959", confidence = Option(1.0), latitude = 14.21, longitude = 43.1)),
+        locations = List(Location(wofId = "wof-85670485", layer = "country", confidence = Option(1.0), latitude = 12.21, longitude = 43.1), Location(wofId = "wof-85680959", layer = "country", confidence = Option(1.0), latitude = 14.21, longitude = 43.1)),
         keywords = List(Tag(name = "isis", confidence = Option(1.0)), Tag(name ="car", confidence = Option(1.0))),
        //todo genders = List(Tag(name = "male", confidence = Option(1.0)), Tag(name ="female", confidence = Option(1.0))),
         entities = List(Tag(name = "putin", confidence = Option(1.0))),
@@ -85,7 +85,7 @@ object CassandraTest {
           title = "twitter post" ),
         analysis = Analysis(
           sentiments = List(.6),
-          locations = List(Location(wofId = "wof-85670485", confidence = Option(1.0), latitude = 12.21, longitude = 43.1)),
+          locations = List(Location(wofId = "wof-85670485", layer = "country", confidence = Option(1.0), latitude = 12.21, longitude = 43.1)),
           keywords = List(Tag(name = "isis", confidence = Option(1.0)),
             Tag(name ="car", confidence = Option(1.0)),
             Tag(name ="bomb", confidence = Option(1.0)),
@@ -107,7 +107,7 @@ object CassandraTest {
           title = "twitter post" ),
         analysis = Analysis(
           sentiments = List(.6),
-          locations = List(Location(wofId = "wof-85670485", confidence = Option(1.0), latitude = 12.21, longitude = 43.1)),
+          locations = List(Location(wofId = "wof-85670485", layer = "coutry", confidence = Option(1.0), latitude = 12.21, longitude = 43.1)),
           keywords = List(Tag(name = "isis", confidence = Option(1.0)), Tag(name ="fear", confidence = Option(1.0)), Tag(name ="bomb", confidence = Option(1.0)), Tag(name ="fatalities", confidence = Option(1.0))),
           //todo genders = List(Tag(name = "male", confidence = Option(1.0)), Tag(name ="female", confidence = Option(1.0))),
           entities = List(Tag(name = "putin", confidence = Option(1.0))),

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/CassandraTest.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/CassandraTest.scala
@@ -107,7 +107,7 @@ object CassandraTest {
           title = "twitter post" ),
         analysis = Analysis(
           sentiments = List(.6),
-          locations = List(Location(wofId = "wof-85670485", layer = "coutry", confidence = Option(1.0), latitude = 12.21, longitude = 43.1)),
+          locations = List(Location(wofId = "wof-85670485", layer = "country", confidence = Option(1.0), latitude = 12.21, longitude = 43.1)),
           keywords = List(Tag(name = "isis", confidence = Option(1.0)), Tag(name ="fear", confidence = Option(1.0)), Tag(name ="bomb", confidence = Option(1.0)), Tag(name ="fatalities", confidence = Option(1.0))),
           //todo genders = List(Tag(name = "male", confidence = Option(1.0)), Tag(name ="female", confidence = Option(1.0))),
           entities = List(Tag(name = "putin", confidence = Option(1.0))),

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/dto/FortisEvent.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/dto/FortisEvent.scala
@@ -57,46 +57,29 @@ object Location {
    * @see https://github.com/whosonfirst/whosonfirst-placetypes
    */
   def layerToInt(layer: String): Int = {
-    if ("continent".equalsIgnoreCase(layer)) {
-      1090
-    } else if ("empire".equalsIgnoreCase(layer)) {
-      1080
-    } else if ("country".equalsIgnoreCase(layer)) {
-      1070
-    } else if ("dependency".equalsIgnoreCase(layer) || "disputed".equalsIgnoreCase(layer)) {
-      1065
-    } else if ("macroregion".equalsIgnoreCase(layer)) {
-      1060
-    } else if ("region".equalsIgnoreCase(layer)) {
-      1050
-    } else if ("macrocounty".equalsIgnoreCase(layer)){
-      1040
-    } else if ("county".equalsIgnoreCase(layer)) {
-      1030
-    } else if ("metro area".equalsIgnoreCase(layer) || "localadmin".equalsIgnoreCase(layer)) {
-      1020
-    } else if ("locality".equalsIgnoreCase(layer)) {
-      1010
-    } else if ("borough".equalsIgnoreCase(layer)) {
-      1005
-    } else if ("macrohood".equalsIgnoreCase(layer)) {
-      1000
-    } else if ("neighbourhood".equalsIgnoreCase(layer)) {
-      990
-    } else if ("microhood".equalsIgnoreCase(layer)) {
-      980
-    } else if ("campus".equalsIgnoreCase(layer)) {
-      970
-    } else if ("building".equalsIgnoreCase(layer)) {
-      960
-    } else if ("address".equalsIgnoreCase(layer)) {
-      950
-    } else if ("venue".equalsIgnoreCase(layer)) {
-      940
-    } else {
-      // we usually care about the most granular location values
-      // so it's fine to treat unknown values as greater than all
-      99999999
+    Option(layer).map(_.toLowerCase) match {
+      case Some("continent") =>     4000
+      case Some("empire") =>        3900
+      case Some("country") =>       3800
+      case Some("dependency") |
+           Some("disputed") =>      3700
+      case Some("macroregion") =>   3600
+      case Some("region") =>        3500
+      case Some("macrocounty") =>   3400
+      case Some("county") =>        3300
+      case Some("metro area") |
+           Some("localadmin") =>    3200
+      case Some("locality") =>      3100
+      case Some("borough") =>       3000
+      case Some("macrohood") =>     2900
+      case Some("neighbourhood") => 2800
+      case Some("microhood") =>     2700
+      case Some("campus") =>        2600
+      case Some("building") =>      2500
+      case Some("address") =>       2400
+      case Some("venue") =>         2300
+      case _ =>                     999999 // we usually care about the most granular location values
+                                           // so it's fine to treat unknown values as greater than all
     }
   }
 }

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/dto/FortisEvent.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/dto/FortisEvent.scala
@@ -32,10 +32,11 @@ case class Analysis(
 
 case class Location(
   wofId: String,
+  layer: String,
   latitude: Double,
   longitude: Double,
   confidence: Option[Double] = None
-) {
+) extends Ordered[Location] {
 
   override def equals(obj: scala.Any): Boolean = {
     if (obj == null) return false
@@ -45,6 +46,59 @@ case class Location(
   }
 
   override def hashCode(): Int = wofId.hashCode
+
+  override def compare(that: Location): Int = {
+    Location.layerToInt(layer).compare(Location.layerToInt(that.layer))
+  }
+}
+
+object Location {
+  /**
+   * @see https://github.com/whosonfirst/whosonfirst-placetypes
+   */
+  def layerToInt(layer: String): Int = {
+    if ("continent".equalsIgnoreCase(layer)) {
+      1090
+    } else if ("empire".equalsIgnoreCase(layer)) {
+      1080
+    } else if ("country".equalsIgnoreCase(layer)) {
+      1070
+    } else if ("dependency".equalsIgnoreCase(layer) || "disputed".equalsIgnoreCase(layer)) {
+      1065
+    } else if ("macroregion".equalsIgnoreCase(layer)) {
+      1060
+    } else if ("region".equalsIgnoreCase(layer)) {
+      1050
+    } else if ("macrocounty".equalsIgnoreCase(layer)){
+      1040
+    } else if ("county".equalsIgnoreCase(layer)) {
+      1030
+    } else if ("metro area".equalsIgnoreCase(layer) || "localadmin".equalsIgnoreCase(layer)) {
+      1020
+    } else if ("locality".equalsIgnoreCase(layer)) {
+      1010
+    } else if ("borough".equalsIgnoreCase(layer)) {
+      1005
+    } else if ("macrohood".equalsIgnoreCase(layer)) {
+      1000
+    } else if ("neighbourhood".equalsIgnoreCase(layer)) {
+      990
+    } else if ("microhood".equalsIgnoreCase(layer)) {
+      980
+    } else if ("campus".equalsIgnoreCase(layer)) {
+      970
+    } else if ("building".equalsIgnoreCase(layer)) {
+      960
+    } else if ("address".equalsIgnoreCase(layer)) {
+      950
+    } else if ("venue".equalsIgnoreCase(layer)) {
+      940
+    } else {
+      // we usually care about the most granular location values
+      // so it's fine to treat unknown values as greater than all
+      99999999
+    }
+  }
 }
 
 case class Tag(

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/transforms/locations/LocationsExtractorFactory.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/transforms/locations/LocationsExtractorFactory.scala
@@ -27,7 +27,7 @@ class LocationsExtractorFactory(
         logDebug(s"Discarding location ${oldLocation.wofId} for name $locationName as we now have more granular location ${newLocation.wofId}")
         map(locationName) = newLocation
       } else {
-        logDebug(s"Discarding location ${newLocation.wofId} for name $locationName since we already have more granular location ${oldLocation.wofId}")
+        logDebug(s"Ignoring location ${newLocation.wofId} for name $locationName since we already have more granular location ${oldLocation.wofId}")
       }
     })
 

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/transforms/locations/LocationsExtractorFactory.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/transforms/locations/LocationsExtractorFactory.scala
@@ -15,14 +15,23 @@ class LocationsExtractorFactory(
   protected var lookup: Map[String, Set[Location]] = _
 
   def buildLookup(): this.type = {
-    val map = mutable.Map[String, mutable.Set[Location]]()
-    featureServiceClient.bbox(geofence).foreach(location => {
-      val key = location.name.toLowerCase
-      val value = toLocation(location)
-      map.getOrElseUpdate(key, mutable.Set()).add(value)
+    val map = mutable.Map[String, Location]()
+    featureServiceClient.bbox(geofence).foreach(feature => {
+      val locationName = feature.name.toLowerCase
+      val newLocation = toLocation(feature)
+      val oldLocation = map.get(locationName).orNull
+      if (oldLocation == null) {
+        logDebug(s"Got new location for name $locationName: ${newLocation.wofId}")
+        map(locationName) = newLocation
+      } else if (newLocation < oldLocation) {
+        logDebug(s"Discarding location ${oldLocation.wofId} for name $locationName as we now have more granular location ${newLocation.wofId}")
+        map(locationName) = newLocation
+      } else {
+        logDebug(s"Discarding location ${newLocation.wofId} for name $locationName since we already have more granular location ${oldLocation.wofId}")
+      }
     })
 
-    lookup = map.map(kv => (kv._1, kv._2.toSet)).toMap
+    lookup = map.map(kv => (kv._1, Set(kv._2))).toMap
     logDebug(s"Built lookup for $geofence with ${lookup.size} locations")
     this
   }

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/transforms/locations/dto/Json.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/transforms/locations/dto/Json.scala
@@ -12,6 +12,7 @@ object FeatureServiceFeature {
   def toLocation(feature: FeatureServiceFeature): Location = {
     Location(
       wofId = feature.id,
+      layer = feature.layer,
       longitude = feature.centroid.map(_.head).getOrElse(DefaultLongitude),
       latitude = feature.centroid.map(_.tail.head).getOrElse(DefaultLatitude))
   }

--- a/src/test/scala/com/microsoft/partnercatalyst/fortis/spark/dto/FortisEventSpec.scala
+++ b/src/test/scala/com/microsoft/partnercatalyst/fortis/spark/dto/FortisEventSpec.scala
@@ -1,0 +1,24 @@
+package com.microsoft.partnercatalyst.fortis.spark.dto
+
+import org.scalatest.FlatSpec
+
+class FortisEventSpec extends FlatSpec {
+  "The Fortis event" should "have an ordering defined by layer" in {
+    val country1 = Location(wofId = "id1", latitude = -1, longitude = -1, layer = "country")
+    val country2 = Location(wofId = "id3", latitude = -1, longitude = -1, layer = "country")
+    val neighbourhood = Location(wofId = "id2", latitude = -1, longitude = -1, layer = "neighbourhood")
+
+    assert(country1 > neighbourhood)
+    assert(country1.compare(country2) == 0)
+    assert(neighbourhood < country2)
+  }
+
+  it should "have the ordering handle null and unknown values" in {
+    val country = Location(wofId = "id1", latitude = -1, longitude = -1, layer = "country")
+    val nullLayer = Location(wofId = "id2", latitude = -1, longitude = -1, layer = null)
+    val unknownLayer = Location(wofId = "id3", latitude = -1, longitude = -1, layer = "unknown layer type")
+
+    assert(country < nullLayer)
+    assert(country < unknownLayer)
+  }
+}

--- a/src/test/scala/com/microsoft/partnercatalyst/fortis/spark/transforms/image/ImageAnalyzerSpec.scala
+++ b/src/test/scala/com/microsoft/partnercatalyst/fortis/spark/transforms/image/ImageAnalyzerSpec.scala
@@ -7,7 +7,7 @@ import org.scalatest.FlatSpec
 class TestImageAnalyzer(cognitiveServicesResponse: String) extends ImageAnalyzer(ImageAnalysisAuth("key"), null) {
   override protected def callCognitiveServices(requestBody: String): String = cognitiveServicesResponse
   override def buildRequestBody(imageUrl: String): String = super.buildRequestBody(imageUrl)
-  override def landmarksToLocations(landmarks: Iterable[JsonImageLandmark]): Iterable[Location] = landmarks.map(x => Location(x.name, latitude = -1, longitude = -1, confidence = Some(x.confidence)))
+  override def landmarksToLocations(landmarks: Iterable[JsonImageLandmark]): Iterable[Location] = landmarks.map(x => Location(x.name, layer = "", latitude = -1, longitude = -1, confidence = Some(x.confidence)))
 }
 
 class ImageAnalyzerSpec extends FlatSpec {
@@ -123,7 +123,7 @@ class ImageAnalyzerSpec extends FlatSpec {
       keywords = List(Tag("person", Some(0.98979085683822632)), Tag("man", Some(0.94493889808654785)), Tag("outdoor", Some(0.938492476940155)), Tag("window", Some(0.89513939619064331))),
       summary = Some("Satya Nadella sitting on a bench"),
       entities = List(Tag("Satya Nadella", Some(0.999028444))),
-      locations = List(Location(wofId = "Forbidden City", latitude = -1, longitude = -1, confidence = Some(0.9978346)))
+      locations = List(Location(wofId = "Forbidden City", layer = "city", latitude = -1, longitude = -1, confidence = Some(0.9978346)))
     ))
   }
 

--- a/src/test/scala/com/microsoft/partnercatalyst/fortis/spark/transforms/locations/LocationsExtractorSpec.scala
+++ b/src/test/scala/com/microsoft/partnercatalyst/fortis/spark/transforms/locations/LocationsExtractorSpec.scala
@@ -14,11 +14,11 @@ object LocationsExtractorSpec {
   val lngManhattan = 90
 
   val testLookup = Map(
-    "nyc" -> Set(Location(idNyc, latitude = latNyc, longitude = lngNyc)),
-    "ny" -> Set(Location(idNyc, latitude = latNyc, longitude = lngNyc)),
-    "new york" -> Set(Location(idNyc, latitude = latNyc, longitude = lngNyc)),
-    "big apple" -> Set(Location(idManhattan, latitude = latManhattan, longitude = lngManhattan)),
-    "manhattan" -> Set(Location(idManhattan, latitude = latManhattan, longitude = lngManhattan))
+    "nyc" -> Set(Location(idNyc, latitude = latNyc, longitude = lngNyc, layer = "city")),
+    "ny" -> Set(Location(idNyc, latitude = latNyc, longitude = lngNyc, layer = "city")),
+    "new york" -> Set(Location(idNyc, latitude = latNyc, longitude = lngNyc, layer = "city")),
+    "big apple" -> Set(Location(idManhattan, latitude = latManhattan, longitude = lngManhattan, layer = "city")),
+    "manhattan" -> Set(Location(idManhattan, latitude = latManhattan, longitude = lngManhattan, layer = "city"))
   )
 }
 
@@ -48,8 +48,8 @@ class LocationsExtractorSpec extends FlatSpec {
 
   it should "build the locations lookup" in {
     val client = new TestFeatureServiceClient(Seq(
-      FeatureServiceFeature(id = "id1", name = "New York", layer = "city"),
-      FeatureServiceFeature(id = "id2", name = "New York", layer = "state"),
+      FeatureServiceFeature(id = "id1", name = "New York", layer = "metro area"),
+      FeatureServiceFeature(id = "id2", name = "New York", layer = "macroregion"),
       FeatureServiceFeature(id = "id3", name = "Gowanus Heights", layer = "neighbourhood")
     ), null)
 
@@ -57,7 +57,7 @@ class LocationsExtractorSpec extends FlatSpec {
     val lookup = extractorFactory.getLookup
 
     assert(lookup.size == 2)
-    assert(lookup("new york").map(_.wofId) == Set("id1", "id2"))
+    assert(lookup("new york").map(_.wofId) == Set("id1"))
     assert(lookup("gowanus heights").map(_.wofId) == Set("id3"))
   }
 

--- a/src/test/scala/com/microsoft/partnercatalyst/fortis/spark/transforms/locations/client/FeatureServiceClientSpec.scala
+++ b/src/test/scala/com/microsoft/partnercatalyst/fortis/spark/transforms/locations/client/FeatureServiceClientSpec.scala
@@ -35,13 +35,13 @@ class FeatureServiceClientSpec extends FlatSpec {
 
   it should "convert features to locations" in {
     val feature = FeatureServiceFeature(id = "wof-102061079", name = "Gowanus Heights", layer = "neighbourhood", centroid = None)
-    val location = Location(wofId = "wof-102061079", confidence = None, longitude = DefaultLongitude, latitude = DefaultLatitude)
+    val location = Location(wofId = "wof-102061079", layer = "country", confidence = None, longitude = DefaultLongitude, latitude = DefaultLatitude)
     assert(location == toLocation(feature))
   }
 
   it should "convert features to locations with centroids" in {
     val feature = FeatureServiceFeature(id = "wof-102061079", name = "Gowanus Heights", layer = "neighbourhood", centroid = Some(List(-1.2, 3.4)))
-    val location = Location(wofId = "wof-102061079", confidence = None, longitude = -1.2, latitude = 3.4)
+    val location = Location(wofId = "wof-102061079", layer = "country", confidence = None, longitude = -1.2, latitude = 3.4)
     assert(location == toLocation(feature))
   }
 }


### PR DESCRIPTION
For example, if we have a location name that is both a city and a state (like "New York") we only want to keep the city.

Implementation note: keeping the LocationExtractorFactory's lookup field as a `Map[String, Set[Location]]` although only a single location will be in the set after this change to avoid changing the public API of the factory (i.e., minimize risk surface).