### PR TITLE
Extend blacklist to locations and entities

### DIFF
--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/CassandraTest.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/CassandraTest.scala
@@ -72,7 +72,7 @@ object CassandraTest {
         title = "twitter post" ),
       analysis = Analysis(
         sentiments = List(.5),
-        locations = List(Location(wofId = "wof-85670485", layer = "country", confidence = Option(1.0), latitude = 12.21, longitude = 43.1), Location(wofId = "wof-85680959", layer = "country", confidence = Option(1.0), latitude = 14.21, longitude = 43.1)),
+        locations = List(Location(wofId = "wof-85670485", name = "neverland", layer = "country", confidence = Option(1.0), latitude = 12.21, longitude = 43.1), Location(wofId = "wof-85680959", name = "neverland", layer = "country", confidence = Option(1.0), latitude = 14.21, longitude = 43.1)),
         keywords = List(Tag(name = "isis", confidence = Option(1.0)), Tag(name ="car", confidence = Option(1.0))),
        //todo genders = List(Tag(name = "male", confidence = Option(1.0)), Tag(name ="female", confidence = Option(1.0))),
         entities = List(Tag(name = "putin", confidence = Option(1.0))),
@@ -91,7 +91,7 @@ object CassandraTest {
           title = "twitter post" ),
         analysis = Analysis(
           sentiments = List(.6),
-          locations = List(Location(wofId = "wof-85670485", layer = "country", confidence = Option(1.0), latitude = 12.21, longitude = 43.1)),
+          locations = List(Location(wofId = "wof-85670485", name = "neverland", layer = "country", confidence = Option(1.0), latitude = 12.21, longitude = 43.1)),
           keywords = List(Tag(name = "isis", confidence = Option(1.0)),
             Tag(name ="car", confidence = Option(1.0)),
             Tag(name ="bomb", confidence = Option(1.0)),
@@ -113,7 +113,7 @@ object CassandraTest {
           title = "twitter post" ),
         analysis = Analysis(
           sentiments = List(.6),
-          locations = List(Location(wofId = "wof-85670485", layer = "country", confidence = Option(1.0), latitude = 12.21, longitude = 43.1)),
+          locations = List(Location(wofId = "wof-85670485", name = "neverland", layer = "country", confidence = Option(1.0), latitude = 12.21, longitude = 43.1)),
           keywords = List(Tag(name = "isis", confidence = Option(1.0)), Tag(name ="fear", confidence = Option(1.0)), Tag(name ="bomb", confidence = Option(1.0)), Tag(name ="fatalities", confidence = Option(1.0))),
           //todo genders = List(Tag(name = "male", confidence = Option(1.0)), Tag(name ="female", confidence = Option(1.0))),
           entities = List(Tag(name = "putin", confidence = Option(1.0))),

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/analyzer/AnalysisDefaults.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/analyzer/AnalysisDefaults.scala
@@ -1,6 +1,6 @@
 package com.microsoft.partnercatalyst.fortis.spark.analyzer
 
-import com.microsoft.partnercatalyst.fortis.spark.dto.{Location, Tag}
+import com.microsoft.partnercatalyst.fortis.spark.dto.{Analysis, Location, Tag}
 import com.microsoft.partnercatalyst.fortis.spark.transforms.language.LanguageDetector
 import com.microsoft.partnercatalyst.fortis.spark.transforms.locations.LocationsExtractor
 import com.microsoft.partnercatalyst.fortis.spark.transforms.people.PeopleRecognizer
@@ -21,6 +21,8 @@ private[analyzer] object AnalysisDefaults {
     with EnableEntity[T]
     with EnableLanguage[T]
     with EnableBlacklist[T]
+    with EnableLocationsBlacklist[T]
+    with EnableEntitiesBlacklist[T]
     with EnableSummary[T]
     with EnableSentiment[T] {
     this: Analyzer[T] =>
@@ -67,6 +69,23 @@ private[analyzer] object AnalysisDefaults {
     this: Analyzer[T] =>
     override def hasBlacklistedTerms(details: ExtendedDetails[T], blacklist: Blacklist): Boolean = {
       blacklist.matches(details.body) || blacklist.matches(details.title)
+    }
+  }
+
+  trait EnableLocationsBlacklist[T] {
+    this: Analyzer[T] =>
+    override def hasBlacklistedLocations(details: ExtendedDetails[T], analysis: Analysis, blacklist: Blacklist): Boolean = {
+      val sharedLocations = details.sharedLocations.map(_.name).toSet
+      val analyzedLocations = analysis.locations.map(_.name).toSet
+      blacklist.matches(sharedLocations) || blacklist.matches(analyzedLocations)
+    }
+  }
+
+  trait EnableEntitiesBlacklist[T] {
+    this: Analyzer[T] =>
+    override def hasBlacklistedEntities(analysis: Analysis, blacklist: Blacklist): Boolean = {
+      val entities = analysis.entities.map(_.name).toSet
+      blacklist.matches(entities)
     }
   }
 

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/analyzer/Analyzer.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/analyzer/Analyzer.scala
@@ -1,6 +1,6 @@
 package com.microsoft.partnercatalyst.fortis.spark.analyzer
 
-import com.microsoft.partnercatalyst.fortis.spark.dto.{Location, Tag}
+import com.microsoft.partnercatalyst.fortis.spark.dto.{Analysis, Location, Tag}
 import com.microsoft.partnercatalyst.fortis.spark.transforms.image.ImageAnalyzer
 import com.microsoft.partnercatalyst.fortis.spark.transforms.language.LanguageDetector
 import com.microsoft.partnercatalyst.fortis.spark.transforms.locations.LocationsExtractor
@@ -14,6 +14,8 @@ trait Analyzer[T] {
 
   def toSchema(item: T, locationFetcher: LocationFetcher, imageAnalyzer: ImageAnalyzer): ExtendedDetails[T]
   def hasBlacklistedTerms(details: ExtendedDetails[T], blacklist: Blacklist): Boolean
+  def hasBlacklistedLocations(details: ExtendedDetails[T], analysis: Analysis, blacklist: Blacklist): Boolean
+  def hasBlacklistedEntities(analysis: Analysis, blacklist: Blacklist): Boolean
   def extractKeywords(details: ExtendedDetails[T], keywordExtractor: KeywordExtractor): List[Tag]
   def extractLocations(details: ExtendedDetails[T], locationsExtractor: LocationsExtractor): List[Location]
   def extractEntities(details: ExtendedDetails[T], peopleRecognizer: PeopleRecognizer): List[Tag]

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/analyzer/InstagramAnalyzer.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/analyzer/InstagramAnalyzer.scala
@@ -12,6 +12,8 @@ import com.microsoft.partnercatalyst.fortis.spark.transforms.summary.Summarizer
 @SerialVersionUID(100L)
 class InstagramAnalyzer extends Analyzer[InstagramItem] with Serializable
   with AnalysisDefaults.EnableBlacklist[InstagramItem]
+  with AnalysisDefaults.EnableLocationsBlacklist[InstagramItem]
+  with AnalysisDefaults.EnableEntitiesBlacklist[InstagramItem]
   with AnalysisDefaults.EnableKeyword[InstagramItem] {
   override def toSchema(item: InstagramItem, locationFetcher: LocationFetcher, imageAnalyzer: ImageAnalyzer): ExtendedDetails[InstagramItem] = {
     val imageAnalysis = imageAnalyzer.analyze(item.images.standard_resolution.url)

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/dto/FortisEvent.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/dto/FortisEvent.scala
@@ -34,6 +34,7 @@ case class Analysis(
 
 case class Location(
   wofId: String,
+  name: String,
   layer: String,
   latitude: Double,
   longitude: Double,

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/transforms/locations/dto/Json.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/transforms/locations/dto/Json.scala
@@ -12,6 +12,7 @@ object FeatureServiceFeature {
   def toLocation(feature: FeatureServiceFeature): Location = {
     Location(
       wofId = feature.id,
+      name = feature.name,
       layer = feature.layer,
       longitude = feature.centroid.map(_.head).getOrElse(DefaultLongitude),
       latitude = feature.centroid.map(_.tail.head).getOrElse(DefaultLatitude))

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/transforms/topic/Blacklist.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/transforms/topic/Blacklist.scala
@@ -13,4 +13,8 @@ class Blacklist(blacklist: Seq[BlacklistedTerm]) extends Serializable {
     val tokens = Tokenizer(text).toSet
     blacklist.exists(entry => entry.conjunctiveFilter.forall(tokens.contains))
   }
+
+  def matches(terms: Set[String]): Boolean = {
+    blacklist.exists(entry => entry.conjunctiveFilter.forall(terms.contains))
+  }
 }

--- a/src/test/scala/com/microsoft/partnercatalyst/fortis/spark/dto/FortisEventSpec.scala
+++ b/src/test/scala/com/microsoft/partnercatalyst/fortis/spark/dto/FortisEventSpec.scala
@@ -4,9 +4,9 @@ import org.scalatest.FlatSpec
 
 class FortisEventSpec extends FlatSpec {
   "The Fortis event" should "have an ordering defined by layer" in {
-    val country1 = Location(wofId = "id1", latitude = -1, longitude = -1, layer = "country")
-    val country2 = Location(wofId = "id3", latitude = -1, longitude = -1, layer = "country")
-    val neighbourhood = Location(wofId = "id2", latitude = -1, longitude = -1, layer = "neighbourhood")
+    val country1 = Location(wofId = "id1", name = "country1", latitude = -1, longitude = -1, layer = "country")
+    val country2 = Location(wofId = "id3", name = "country2", latitude = -1, longitude = -1, layer = "country")
+    val neighbourhood = Location(wofId = "id2", name = "neighbourhood", latitude = -1, longitude = -1, layer = "neighbourhood")
 
     assert(country1 > neighbourhood)
     assert(country1.compare(country2) == 0)
@@ -14,9 +14,9 @@ class FortisEventSpec extends FlatSpec {
   }
 
   it should "have the ordering handle null and unknown values" in {
-    val country = Location(wofId = "id1", latitude = -1, longitude = -1, layer = "country")
-    val nullLayer = Location(wofId = "id2", latitude = -1, longitude = -1, layer = null)
-    val unknownLayer = Location(wofId = "id3", latitude = -1, longitude = -1, layer = "unknown layer type")
+    val country = Location(wofId = "id1", name = "coutry", latitude = -1, longitude = -1, layer = "country")
+    val nullLayer = Location(wofId = "id2", name = "null island", latitude = -1, longitude = -1, layer = null)
+    val unknownLayer = Location(wofId = "id3", name = "unknown city", latitude = -1, longitude = -1, layer = "unknown layer type")
 
     assert(country < nullLayer)
     assert(country < unknownLayer)

--- a/src/test/scala/com/microsoft/partnercatalyst/fortis/spark/transforms/image/ImageAnalyzerSpec.scala
+++ b/src/test/scala/com/microsoft/partnercatalyst/fortis/spark/transforms/image/ImageAnalyzerSpec.scala
@@ -7,7 +7,7 @@ import org.scalatest.FlatSpec
 class TestImageAnalyzer(cognitiveServicesResponse: String) extends ImageAnalyzer(ImageAnalysisAuth("key"), null) {
   override protected def callCognitiveServices(requestBody: String): String = cognitiveServicesResponse
   override def buildRequestBody(imageUrl: String): String = super.buildRequestBody(imageUrl)
-  override def landmarksToLocations(landmarks: Iterable[JsonImageLandmark]): Iterable[Location] = landmarks.map(x => Location(x.name, layer = "", latitude = -1, longitude = -1, confidence = Some(x.confidence)))
+  override def landmarksToLocations(landmarks: Iterable[JsonImageLandmark]): Iterable[Location] = landmarks.map(x => Location(x.name, name = x.name, layer = "", latitude = -1, longitude = -1, confidence = Some(x.confidence)))
 }
 
 class ImageAnalyzerSpec extends FlatSpec {
@@ -123,7 +123,7 @@ class ImageAnalyzerSpec extends FlatSpec {
       keywords = List(Tag("person", Some(0.98979085683822632)), Tag("man", Some(0.94493889808654785)), Tag("outdoor", Some(0.938492476940155)), Tag("window", Some(0.89513939619064331))),
       summary = Some("Satya Nadella sitting on a bench"),
       entities = List(Tag("Satya Nadella", Some(0.999028444))),
-      locations = List(Location(wofId = "Forbidden City", layer = "city", latitude = -1, longitude = -1, confidence = Some(0.9978346)))
+      locations = List(Location(wofId = "Forbidden City", name = "Forbidden City", layer = "city", latitude = -1, longitude = -1, confidence = Some(0.9978346)))
     ))
   }
 

--- a/src/test/scala/com/microsoft/partnercatalyst/fortis/spark/transforms/locations/LocationsExtractorSpec.scala
+++ b/src/test/scala/com/microsoft/partnercatalyst/fortis/spark/transforms/locations/LocationsExtractorSpec.scala
@@ -14,11 +14,11 @@ object LocationsExtractorSpec {
   val lngManhattan = 90
 
   val testLookup = Map(
-    "nyc" -> Set(Location(idNyc, latitude = latNyc, longitude = lngNyc, layer = "city")),
-    "ny" -> Set(Location(idNyc, latitude = latNyc, longitude = lngNyc, layer = "city")),
-    "new york" -> Set(Location(idNyc, latitude = latNyc, longitude = lngNyc, layer = "city")),
-    "big apple" -> Set(Location(idManhattan, latitude = latManhattan, longitude = lngManhattan, layer = "city")),
-    "manhattan" -> Set(Location(idManhattan, latitude = latManhattan, longitude = lngManhattan, layer = "city"))
+    "nyc" -> Set(Location(idNyc, name = "nyc", latitude = latNyc, longitude = lngNyc, layer = "city")),
+    "ny" -> Set(Location(idNyc, name = "ny", latitude = latNyc, longitude = lngNyc, layer = "city")),
+    "new york" -> Set(Location(idNyc, name = "new york", latitude = latNyc, longitude = lngNyc, layer = "city")),
+    "big apple" -> Set(Location(idManhattan, name = "big apple", latitude = latManhattan, longitude = lngManhattan, layer = "city")),
+    "manhattan" -> Set(Location(idManhattan, name = "manhattan", latitude = latManhattan, longitude = lngManhattan, layer = "city"))
   )
 }
 

--- a/src/test/scala/com/microsoft/partnercatalyst/fortis/spark/transforms/locations/client/FeatureServiceClientSpec.scala
+++ b/src/test/scala/com/microsoft/partnercatalyst/fortis/spark/transforms/locations/client/FeatureServiceClientSpec.scala
@@ -35,13 +35,13 @@ class FeatureServiceClientSpec extends FlatSpec {
 
   it should "convert features to locations" in {
     val feature = FeatureServiceFeature(id = "wof-102061079", name = "Gowanus Heights", layer = "neighbourhood", centroid = None)
-    val location = Location(wofId = "wof-102061079", layer = "country", confidence = None, longitude = DefaultLongitude, latitude = DefaultLatitude)
+    val location = Location(wofId = "wof-102061079", name = "Gowanus Heights", layer = "country", confidence = None, longitude = DefaultLongitude, latitude = DefaultLatitude)
     assert(location == toLocation(feature))
   }
 
   it should "convert features to locations with centroids" in {
     val feature = FeatureServiceFeature(id = "wof-102061079", name = "Gowanus Heights", layer = "neighbourhood", centroid = Some(List(-1.2, 3.4)))
-    val location = Location(wofId = "wof-102061079", layer = "country", confidence = None, longitude = -1.2, latitude = 3.4)
+    val location = Location(wofId = "wof-102061079", name = "Gowanus Heights", layer = "country", confidence = None, longitude = -1.2, latitude = 3.4)
     assert(location == toLocation(feature))
   }
 }

--- a/src/test/scala/com/microsoft/partnercatalyst/fortis/spark/transforms/topic/BlacklistSpec.scala
+++ b/src/test/scala/com/microsoft/partnercatalyst/fortis/spark/transforms/topic/BlacklistSpec.scala
@@ -8,22 +8,29 @@ class BlacklistSpec extends FlatSpec {
     val blacklist = new Blacklist(Seq(BlacklistedTerm(Set("foo"))))
     assert(blacklist.matches("foo bar"))
     assert(!blacklist.matches("bar baz"))
+    assert(blacklist.matches("foo bar".split(" ").toSet))
+    assert(!blacklist.matches("bar baz".split(" ").toSet))
   }
 
   it should "match conjunctions" in {
     val blacklist = new Blacklist(Seq(BlacklistedTerm(Set("foo", "bar"))))
     assert(blacklist.matches("bar baz foo"))
     assert(!blacklist.matches("bar baz"))
+    assert(blacklist.matches("bar baz foo".split(" ").toSet))
+    assert(!blacklist.matches("bar baz".split(" ").toSet))
   }
 
   it should "match any conjunctions" in {
     val blacklist = new Blacklist(Seq(BlacklistedTerm(Set("foo", "bar")), BlacklistedTerm(Set("pear"))))
     assert(blacklist.matches("a b pear c"))
     assert(blacklist.matches("bar baz foo"))
+    assert(blacklist.matches("a b pear c".split(" ").toSet))
+    assert(blacklist.matches("bar baz foo".split(" ").toSet))
   }
 
   it should "handle the empty string" in {
     val blacklist = new Blacklist(Seq(BlacklistedTerm(Set("foo", "bar")), BlacklistedTerm(Set("pear"))))
     assert(!blacklist.matches(""))
+    assert(!blacklist.matches(Set[String]()))
   }
 }


### PR DESCRIPTION
Example situation of when this is useful: currently there is lots of talk about the hurricane in Florida, US. There's also a city called Florida in Colombia, however, that Fortis site wouldn't want to pick up all the events related to Florida, US.