### PR TITLE
Optimize aggregators: partitioning and caching

### DIFF
--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/sinks/cassandra/aggregators/ConjunctiveTopicsOffineAggregator.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/sinks/cassandra/aggregators/ConjunctiveTopicsOffineAggregator.scala
@@ -11,13 +11,7 @@ class ConjunctiveTopicsOffineAggregator(configurationManager: ConfigurationManag
 
   override def aggregate(events: RDD[Event]): RDD[ConjunctiveTopic] = {
     val siteSettings = configurationManager.fetchSiteSettings(events.sparkContext)
-    val conjunctiveTopics = events.flatMap(event=>{
-      Seq(
-        event,
-        event.copy(externalsourceid = "all"),
-        event.copy(pipelinekey = "all", externalsourceid = "all")
-      )
-    }).flatMap(CassandraConjunctiveTopics(_, siteSettings.defaultzoom))
+    val conjunctiveTopics = events.flatMap(CassandraConjunctiveTopics(_, siteSettings.defaultzoom))
 
     conjunctiveTopics.keyBy(r=>{(
       r.pipelinekey, r.externalsourceid,

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/sinks/cassandra/aggregators/PopularPlacesOfflineAggregator.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/sinks/cassandra/aggregators/PopularPlacesOfflineAggregator.scala
@@ -11,13 +11,7 @@ class PopularPlacesOfflineAggregator(configurationManager: ConfigurationManager)
 
   override def aggregate(events: RDD[Event]): RDD[PopularPlace] = {
     val siteSettings = configurationManager.fetchSiteSettings(events.sparkContext)
-    val places = events.flatMap(event=>{
-      Seq(
-        event,
-        event.copy(externalsourceid = "all"),
-        event.copy(pipelinekey = "all", externalsourceid = "all")
-      )
-    }).flatMap(CassandraPopularPlaces(_, siteSettings.defaultzoom))
+    val places = events.flatMap(CassandraPopularPlaces(_, siteSettings.defaultzoom))
 
     places.keyBy(r=>{(
       r.placeid,

--- a/src/test/scala/com/microsoft/partnercatalyst/fortis/spark/sinks/cassandra/aggregators/ConjunctiveTopicsOffineAggregatorTestSpec.scala
+++ b/src/test/scala/com/microsoft/partnercatalyst/fortis/spark/sinks/cassandra/aggregators/ConjunctiveTopicsOffineAggregatorTestSpec.scala
@@ -76,7 +76,15 @@ class ConjunctiveTopicsOffineAggregatorTestSpec extends FlatSpec with BeforeAndA
       title = ""
     )))
 
-    val topics = aggregator.aggregate(events).collect()
+    val eventsExploded = events.flatMap(event=>{
+      Seq(
+        event,
+        event.copy(externalsourceid = "all"),
+        event.copy(pipelinekey = "all", externalsourceid = "all")
+      )
+    })
+
+    val topics = aggregator.aggregate(eventsExploded).collect()
     assert(topics.size == 165)
 
     val filteredTopics = topics.filter(topic=>topic.pipelinekey == "all" && topic.externalsourceid == "all" && topic.periodtype == "day" && topic.tilez == 8)
@@ -147,7 +155,15 @@ class ConjunctiveTopicsOffineAggregatorTestSpec extends FlatSpec with BeforeAndA
       )
     ))
 
-    val topics = aggregator.aggregate(events).collect()
+    val eventsExploded = events.flatMap(event=>{
+      Seq(
+        event,
+        event.copy(externalsourceid = "all"),
+        event.copy(pipelinekey = "all", externalsourceid = "all")
+      )
+    })
+
+    val topics = aggregator.aggregate(eventsExploded).collect()
     assert(topics.size == 220)
 
     val allSourcesTopics = topics.filter(topic=>topic.pipelinekey != "all" && topic.externalsourceid == "all" && topic.periodtype == "day" && topic.tilez == 8)
@@ -232,7 +248,15 @@ class ConjunctiveTopicsOffineAggregatorTestSpec extends FlatSpec with BeforeAndA
       )
     ))
 
-    val topics = aggregator.aggregate(events).collect()
+    val eventsExploded = events.flatMap(event=>{
+      Seq(
+        event,
+        event.copy(externalsourceid = "all"),
+        event.copy(pipelinekey = "all", externalsourceid = "all")
+      )
+    })
+
+    val topics = aggregator.aggregate(eventsExploded).collect()
     assert(topics.size == 275)
 
     val allSourcesTopics = topics.filter(topic=>topic.pipelinekey != "all" && topic.externalsourceid == "all" && topic.periodtype == "day" && topic.tilez == 8)

--- a/src/test/scala/com/microsoft/partnercatalyst/fortis/spark/sinks/cassandra/aggregators/PopularPlacesOfflineAggregatorTestSpec.scala
+++ b/src/test/scala/com/microsoft/partnercatalyst/fortis/spark/sinks/cassandra/aggregators/PopularPlacesOfflineAggregatorTestSpec.scala
@@ -76,7 +76,15 @@ class PopularPlacesOfflineAggregatorTestSpec extends FlatSpec with BeforeAndAfte
       title = ""
     )))
 
-    val popularPlaces = aggregator.aggregate(events).collect()
+    val eventsExploded = events.flatMap(event=>{
+      Seq(
+        event,
+        event.copy(externalsourceid = "all"),
+        event.copy(pipelinekey = "all", externalsourceid = "all")
+      )
+    })
+
+    val popularPlaces = aggregator.aggregate(eventsExploded).collect()
     assert(popularPlaces.size == 165)
 
     val allall = popularPlaces.filter(topic=>topic.pipelinekey == "all" && topic.externalsourceid == "all" && topic.periodtype == "day" && topic.tilez == 8)
@@ -169,7 +177,15 @@ class PopularPlacesOfflineAggregatorTestSpec extends FlatSpec with BeforeAndAfte
       )
     ))
 
-    val popularPlaces = aggregator.aggregate(events).collect()
+    val eventsExploded = events.flatMap(event=>{
+      Seq(
+        event,
+        event.copy(externalsourceid = "all"),
+        event.copy(pipelinekey = "all", externalsourceid = "all")
+      )
+    })
+
+    val popularPlaces = aggregator.aggregate(eventsExploded).collect()
     assert(popularPlaces.size == 220)
 
     val allall = popularPlaces.filter(topic=>topic.pipelinekey == "all" && topic.externalsourceid == "all" && topic.periodtype == "day" && topic.tilez == 8)
@@ -262,7 +278,15 @@ class PopularPlacesOfflineAggregatorTestSpec extends FlatSpec with BeforeAndAfte
       )
     ))
 
-    val popularPlaces = aggregator.aggregate(events).collect()
+    val eventsExploded = events.flatMap(event=>{
+      Seq(
+        event,
+        event.copy(externalsourceid = "all"),
+        event.copy(pipelinekey = "all", externalsourceid = "all")
+      )
+    })
+
+    val popularPlaces = aggregator.aggregate(eventsExploded).collect()
     assert(popularPlaces.size == 275)
 
     val allall = popularPlaces.filter(topic=>topic.pipelinekey == "all" && topic.externalsourceid == "all" && topic.periodtype == "day" && topic.tilez == 8)


### PR DESCRIPTION
A higher number of partitions was required to use all cores of all executors. Default parallelism is num cores available across all of Spark, but many examples multiply this by 2 (more is better).

Moved event explosion prior to aggregators to avoid recomputing (it can be cached this way).

Current metrics:
<img width="2548" alt="screen shot 2017-09-12 at 2 47 03 pm" src="https://user-images.githubusercontent.com/1374024/30343322-2058d7ae-97cb-11e7-983f-03c783a77f1f.png">
