### PR TITLE
Performance and memory tuning

### DIFF
--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/ProjectFortis.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/ProjectFortis.scala
@@ -60,6 +60,9 @@ object ProjectFortis extends App with Loggable {
       .set("spark.kryo.registrator", "com.microsoft.partnercatalyst.fortis.spark.serialization.KryoRegistrator")
       .set("spark.kryoserializer.buffer", "128k")
       .set("spark.kryoserializer.buffer.max", "64m")
+      .set("spark.network.timeout", "800")
+      .set("spark.sql.broadcastTimeout", "1200")
+      .set("spark.rpc.askTimeout", "30")
     CassandraConfig.init(conf, batchDuration, fortisSettings)
 
     val sparkContext = new SparkContext(conf)

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/sinks/cassandra/CassandraConfig.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/sinks/cassandra/CassandraConfig.scala
@@ -16,5 +16,7 @@ object CassandraConfig {
       .setIfMissing("spark.cassandra.auth.password", CassandraPassword)
       .setIfMissing("spark.cassandra.connection.keep_alive_ms", envOrElse("CASSANDRA_KEEP_ALIVE_MS", (batchDuration.milliseconds * 2).toString))
       .setIfMissing("spark.cassandra.connection.factory", "com.microsoft.partnercatalyst.fortis.spark.sinks.cassandra.FortisConnectionFactory")
+      .set("spark.cassandra.output.batch.size.rows", "1")
+      .set("spark.cassandra.output.concurrent.writes", "2000")
   }
 }

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/sinks/cassandra/CassandraEventsSink.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/sinks/cassandra/CassandraEventsSink.scala
@@ -66,6 +66,8 @@ object CassandraEventsSink extends Loggable {
             writeEventBatchToEventTagTables(eventBatchDF, sparkSession)
           }
 
+          eventBatchDF.unpersist(blocking = true)
+
           val eventsExploded = fortisEventsRDD.flatMap(event=>{
             Seq(
               event,
@@ -87,6 +89,11 @@ object CassandraEventsSink extends Loggable {
               }
             }
           })
+
+          fortisEventsRDDRepartitioned.unpersist(blocking = true)
+          eventsExploded.unpersist(blocking = true)
+          fortisEventsRDD.unpersist(blocking = true)
+          eventsRDD.unpersist(blocking = true)
         }
       }
     }}

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/sinks/cassandra/aggregators/ConjunctiveTopicsOffineAggregator.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/sinks/cassandra/aggregators/ConjunctiveTopicsOffineAggregator.scala
@@ -34,6 +34,8 @@ class ConjunctiveTopicsOffineAggregator(configurationManager: ConfigurationManag
         topics.saveToCassandra(keyspace, "conjunctivetopics")
       }
     }
+
+    topics.unpersist(blocking = true)
   }
 
 }

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/sinks/cassandra/aggregators/ConjunctiveTopicsOffineAggregator.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/sinks/cassandra/aggregators/ConjunctiveTopicsOffineAggregator.scala
@@ -7,6 +7,8 @@ import com.microsoft.partnercatalyst.fortis.spark.sinks.cassandra.CassandraConju
 import com.microsoft.partnercatalyst.fortis.spark.sinks.cassandra.dto.{ConjunctiveTopic, Event}
 import org.apache.spark.rdd.RDD
 
+import com.datastax.spark.connector._
+
 class ConjunctiveTopicsOffineAggregator(configurationManager: ConfigurationManager) extends OfflineAggregator[ConjunctiveTopic] {
 
   override def aggregate(events: RDD[Event]): RDD[ConjunctiveTopic] = {

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/sinks/cassandra/aggregators/HeatmapOfflineAggregator.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/sinks/cassandra/aggregators/HeatmapOfflineAggregator.scala
@@ -85,7 +85,7 @@ class HeatmapOfflineAggregator(session: SparkSession, configurationManager: Conf
         implicit val rowWriter = SqlRowWriter.Factory
         tiles.saveToCassandra(keyspace, "heatmap")
 
-        val tileBuckets = aggregateTileBuckets(tiles, keyspace)
+        val tileBuckets = aggregateTileBuckets(tiles, keyspace).cache()
         tileBuckets.write
           .format("org.apache.spark.sql.cassandra")
           .mode(SaveMode.Append)

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/sinks/cassandra/aggregators/HeatmapOfflineAggregator.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/sinks/cassandra/aggregators/HeatmapOfflineAggregator.scala
@@ -1,26 +1,25 @@
 package com.microsoft.partnercatalyst.fortis.spark.sinks.cassandra.aggregators
 
-import com.datastax.spark.connector._
 import com.datastax.spark.connector.writer.SqlRowWriter
 import com.microsoft.partnercatalyst.fortis.spark.dba.ConfigurationManager
 import com.microsoft.partnercatalyst.fortis.spark.sinks.cassandra.dto.{Event, HeatmapTile}
 import com.microsoft.partnercatalyst.fortis.spark.sinks.cassandra.{CassandraHeatmapTiles, CassandraTileBucket}
 import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.{DataFrame, SaveMode, SparkSession}
+import org.apache.spark.sql.SparkSession
+
+import com.datastax.spark.connector._
 
 class HeatmapOfflineAggregator(session: SparkSession, configurationManager: ConfigurationManager) extends OfflineAggregator[HeatmapTile] {
-  private val ComputedTilesTable = "computedtiles"
-
   override def aggregate(events: RDD[Event]): RDD[HeatmapTile] = {
     val siteSettings = configurationManager.fetchSiteSettings(events.sparkContext)
     val tiles = events.flatMap(CassandraHeatmapTiles(_, siteSettings.defaultzoom))
 
     tiles.keyBy(r=>{(
-      r.heatmaptileid, r.period,
+      r.period,
       r.periodtype, r.perioddate,
       r.conjunctiontopic1, r.conjunctiontopic2, r.conjunctiontopic3,
       r.tileid, r.tilez,
-      r.pipelinekey, r.externalsourceid
+      r.pipelinekey, r.externalsourceid, r.heatmaptileid
     )}).reduceByKey((a,b)=>{
       val mentionCount = a.mentioncount + b.mentioncount
       val sentimentNumerator = a.avgsentimentnumerator + b.avgsentimentnumerator
@@ -31,15 +30,16 @@ class HeatmapOfflineAggregator(session: SparkSession, configurationManager: Conf
     }).values
   }
 
-  private def aggregateTileBuckets(tiles: RDD[HeatmapTile], keyspace: String): DataFrame = {
-    import session.implicits._
-    val tilesComputed = tiles.keyBy(r=>{(
-      r.period,
-      r.periodtype, r.perioddate,
-      r.conjunctiontopic1, r.conjunctiontopic2, r.conjunctiontopic3,
-      r.tileid, r.tilez,
-      r.pipelinekey, r.externalsourceid
-    )}).reduceByKey((a,b)=>{
+  private def aggregateAndSaveTileBuckets(tiles: RDD[HeatmapTile], keyspace: String): Unit = {
+    val tilesComputed = tiles.keyBy(r => {
+      (
+        r.period,
+        r.periodtype, r.perioddate,
+        r.conjunctiontopic1, r.conjunctiontopic2, r.conjunctiontopic3,
+        r.tileid, r.tilez,
+        r.pipelinekey, r.externalsourceid
+      )
+    }).reduceByKey((a, b) => {
       val mentionCount = a.mentioncount + b.mentioncount
       val sentimentNumerator = a.avgsentimentnumerator + b.avgsentimentnumerator
       a.copy(
@@ -48,33 +48,24 @@ class HeatmapOfflineAggregator(session: SparkSession, configurationManager: Conf
       )
     }).values.map(CassandraTileBucket(_))
 
-    val tileBucketDF = tilesComputed.toDF()
+    val reparted = tilesComputed.repartitionByCassandraReplica("fortis", "computedtiles")
 
-    tileBucketDF.createOrReplaceTempView("aggregatedtiles")
+    val updatedRows = reparted.leftJoinWithCassandraTable("fortis", "computedtiles").map(pair => {
+      val generatedTile = pair._1
+      val tileFromCassandra = pair._2
+      tileFromCassandra match {
+        case None => generatedTile
+        case Some(cassandraTile) => generatedTile.copy(
+          mentioncount = generatedTile.mentioncount + cassandraTile.getLong("mentioncount"),
+          avgsentimentnumerator = generatedTile.avgsentimentnumerator + cassandraTile.getLong("avgsentimentnumerator")
+        )
+      }
+    })
 
-    val computedTilesSourceDF = session.read.format("org.apache.spark.sql.cassandra")
-      .options(Map("keyspace" -> keyspace, "table" -> ComputedTilesTable))
-      .load()
+    updatedRows.saveToCassandra("fortis", "computedtiles")
 
-    computedTilesSourceDF.createOrReplaceTempView(ComputedTilesTable)
-
-    val cassandraSave = session.sql(IncrementalUpdateQuery)
-
-    cassandraSave
-  }
-
-  private def IncrementalUpdateQuery: String = {
-    val GroupedBaseColumnNames = Seq("periodtype", "period", "conjunctiontopic1", "conjunctiontopic2", "conjunctiontopic3", "perioddate", "tileid", "tilez", "pipelinekey", "externalsourceid").mkString(",a.")
-
-    s"SELECT a.$GroupedBaseColumnNames, " +
-    s"       a.mentioncount + IF(IsNull(b.mentioncount), 0, b.mentioncount) as mentioncount, " +
-    s"       a.avgsentimentnumerator + IF(IsNull(b.avgsentimentnumerator), 0, b.avgsentimentnumerator) as avgsentimentnumerator " +
-    s"FROM   aggregatedtiles a " +
-    s"LEFT OUTER JOIN ${ComputedTilesTable} b " +
-    s" ON a.pipelinekey = b.pipelinekey and a.periodtype = b.periodtype and a.period = b.period " +
-    s"    and a.externalsourceid = b.externalsourceid and a.conjunctiontopic1 = b.conjunctiontopic1 " +
-    s"    and a.conjunctiontopic2 = b.conjunctiontopic2 and a.conjunctiontopic3 = b.conjunctiontopic3 " +
-    s"    and a.tileid = b.tileid and a.tilez = b.tilez"
+    updatedRows.unpersist(blocking = true)
+    reparted.unpersist(blocking = true)
   }
 
   override def aggregateAndSave(events: RDD[Event], keyspace: String): Unit = {
@@ -84,13 +75,10 @@ class HeatmapOfflineAggregator(session: SparkSession, configurationManager: Conf
       case _ => {
         implicit val rowWriter = SqlRowWriter.Factory
         tiles.saveToCassandra(keyspace, "heatmap")
-
-        val tileBuckets = aggregateTileBuckets(tiles, keyspace).cache()
-        tileBuckets.write
-          .format("org.apache.spark.sql.cassandra")
-          .mode(SaveMode.Append)
-          .options(Map("keyspace" -> keyspace, "table" -> ComputedTilesTable)).save
+        aggregateAndSaveTileBuckets(tiles, keyspace)
       }
     }
+
+    tiles.unpersist(blocking = true)
   }
 }

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/sinks/cassandra/aggregators/PopularPlacesOfflineAggregator.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/sinks/cassandra/aggregators/PopularPlacesOfflineAggregator.scala
@@ -38,6 +38,8 @@ class PopularPlacesOfflineAggregator(configurationManager: ConfigurationManager)
         places.saveToCassandra(keyspace, "popularplaces")
       }
     }
+
+    places.unpersist(blocking = true)
   }
 
 }


### PR DESCRIPTION
* Improves computed tiles aggregation performance: now 4 seconds, was 50.
* Fixes a memory leak caused by an RDD not being unpersisted.
  - We're now explicitly unpersisting cached RDDs. Note this may not be required everwhere. A future changeset will remove explicit calls where they're not needed.
  - Note that all `unpersist()` calls are marked blocking to guarantee memory is freed in time with streaming interval. We may be able to relax this in the future for a slight speedup.
* Changes default write behavior to Cassandra to be single write. This has predictable stability, though we should custom tune write behavior for each aggregator in the future.
* Fixes an issue where SB messages sent to the configuration queue without a properties bag would crash the driver.