### PR TITLE
Add missing column to computed tiles join columns.

### DIFF
--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/sinks/cassandra/aggregators/HeatmapOfflineAggregator.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/sinks/cassandra/aggregators/HeatmapOfflineAggregator.scala
@@ -48,7 +48,7 @@ class HeatmapOfflineAggregator(session: SparkSession, configurationManager: Conf
 
     val reparted = tilesComputed.repartitionByCassandraReplica("fortis", "computedtiles")
 
-    val updatedRows = reparted.leftJoinWithCassandraTable("fortis", "computedtiles").map(pair => {
+    val updatedRows = reparted.leftJoinWithCassandraTable("fortis", "computedtiles", joinColumns = PrimaryKeyColumns).map(pair => {
       val generatedTile = pair._1
       val tileFromCassandra = pair._2
       tileFromCassandra match {


### PR DESCRIPTION
Change `joinColumns` value from `PartitionKey` to `PrimaryKey` in computed tiles join.