### PR TITLE
Tune Cassandra connection pooling.

### DIFF
--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/sinks/cassandra/FortisConnectionFactory.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/sinks/cassandra/FortisConnectionFactory.scala
@@ -1,6 +1,6 @@
 package com.microsoft.partnercatalyst.fortis.spark.sinks.cassandra
 
-import com.datastax.driver.core.Cluster
+import com.datastax.driver.core.{Cluster, HostDistance, PoolingOptions}
 import com.datastax.driver.core.policies.{DCAwareRoundRobinPolicy, TokenAwarePolicy}
 import com.datastax.spark.connector.cql.{CassandraConnectionFactory, CassandraConnectorConf, DefaultConnectionFactory}
 
@@ -8,7 +8,41 @@ object FortisConnectionFactory extends CassandraConnectionFactory {
   override def createCluster(conf: CassandraConnectorConf): Cluster = {
     DefaultConnectionFactory
       .clusterBuilder(conf)
-      .withLoadBalancingPolicy(new TokenAwarePolicy(new DCAwareRoundRobinPolicy.Builder().build()))
+      .withLoadBalancingPolicy(
+        new TokenAwarePolicy(
+          new DCAwareRoundRobinPolicy.Builder()
+            // Denote that our data center should always be treated as local
+            .withLocalDc("dc-eastus2-cassandra")
+            .build()
+        )
+      )
+      .withPoolingOptions(poolingOptions)
       .build()
+  }
+
+  private def poolingOptions: PoolingOptions = {
+    // Reference: http://docs.datastax.com/en/developer/java-driver/3.1/manual/pooling/
+
+    // Note: remote options are set as well, but they should not be used as all nodes are local.
+    new PoolingOptions()
+      // Cassandra binary protocol v3 can support up to 32768 requests per connection.
+      .setMaxRequestsPerConnection(HostDistance.LOCAL, 32768)
+      .setMaxRequestsPerConnection(HostDistance.REMOTE, 2000)
+
+      // Hold 2 connections at all times per node. Each connection can handle 32768 requests (maxed above). The default
+      // is 1 connection per node given high throughput of protocol v3 (we're doubling this).
+      .setConnectionsPerHost(HostDistance.LOCAL,  2, 2)
+      .setConnectionsPerHost(HostDistance.REMOTE, 2, 2)
+
+      // "The heartbeat interval should be set higher than SocketOptions.readTimeoutMillis: the read timeout is the
+      // maximum time that the driver waits for a regular query to complete, therefore the connection should not be
+      // considered idle before it has elapsed."
+      //
+      // Spark connector default for readTimeoutMillis is 2 minutes, while the default here is 30 seconds.
+      // We increase this to > 2 min to satisfy above.  TODO: contribute back to DefaultConnectionFactory
+      .setHeartbeatIntervalSeconds(120 + 10)
+
+      // Increase max queue size from 256 to 320 to avoid BusyPoolException during high load.
+      .setMaxQueueSize(320)
   }
 }

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/sinks/cassandra/FortisConnectionFactory.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/sinks/cassandra/FortisConnectionFactory.scala
@@ -10,11 +10,7 @@ object FortisConnectionFactory extends CassandraConnectionFactory {
       .clusterBuilder(conf)
       .withLoadBalancingPolicy(
         new TokenAwarePolicy(
-          new DCAwareRoundRobinPolicy.Builder()
-            // Denote that our data center should always be treated as local
-            // TODO: uncomment once we can get this predictably from deployment
-            //.withLocalDc("dc-eastus2-cassandra")
-            .build()
+          new DCAwareRoundRobinPolicy.Builder().build()
         )
       )
       .withPoolingOptions(poolingOptions)
@@ -24,7 +20,6 @@ object FortisConnectionFactory extends CassandraConnectionFactory {
   private def poolingOptions: PoolingOptions = {
     // Reference: http://docs.datastax.com/en/developer/java-driver/3.1/manual/pooling/
 
-    // Note: remote options are set as well, but they should not be used as all nodes are local.
     new PoolingOptions()
       // Cassandra binary protocol v3 can support up to 32768 requests per connection.
       .setMaxRequestsPerConnection(HostDistance.LOCAL, 32768)

--- a/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/sinks/cassandra/FortisConnectionFactory.scala
+++ b/src/main/scala/com/microsoft/partnercatalyst/fortis/spark/sinks/cassandra/FortisConnectionFactory.scala
@@ -12,7 +12,8 @@ object FortisConnectionFactory extends CassandraConnectionFactory {
         new TokenAwarePolicy(
           new DCAwareRoundRobinPolicy.Builder()
             // Denote that our data center should always be treated as local
-            .withLocalDc("dc-eastus2-cassandra")
+            // TODO: uncomment once we can get this predictably from deployment
+            //.withLocalDc("dc-eastus2-cassandra")
             .build()
         )
       )


### PR DESCRIPTION
We may need to tune these further through trial and error, but this should be a good start.

* Increases max # requests per connection to Cassandra binary protocol v3 maximum of 32768.
* Doubles max connections used per node (from 1 to 2).
* Increases heartbeat interval beyond readTimeoutMillis as suggested by Datastax documentation.
* Increases max queue size from 256 to 320 to reduce BusyPoolException during high load.

Reference: http://docs.datastax.com/en/developer/java-driver/3.1/manual/pooling/